### PR TITLE
Fix page rerender with useEffect hook

### DIFF
--- a/src/views/donationItemView/index.tsx
+++ b/src/views/donationItemView/index.tsx
@@ -1,4 +1,5 @@
 'use client';
+import React, { useEffect } from 'react';
 import {
   Box,
   Chip,
@@ -75,9 +76,11 @@ export default function DonationItemView({ donations }: DonationItemProps) {
   //map the donation items to the rows
   const { searchString, searchQuery, setSearchQuery } = useSearch();
   const { selectedMonth, monthQuery, setMonthQuery } = useMonth();
-  if (monthQuery === '') {
-    setMonthQuery((new Date().getMonth() + 1).toString()); // Default to current month
-  }
+  useEffect(() => {
+    if (monthQuery === '') {
+      setMonthQuery((new Date().getMonth() + 1).toString());
+    }
+  }, []);
   // const [selectedMonth, setSelectedMonth] = useState<string>(
   //   (new Date().getMonth() + 1).toString() // Default to current month
   // );

--- a/src/views/donationItemView/index.tsx
+++ b/src/views/donationItemView/index.tsx
@@ -76,6 +76,7 @@ export default function DonationItemView({ donations }: DonationItemProps) {
   //map the donation items to the rows
   const { searchString, searchQuery, setSearchQuery } = useSearch();
   const { selectedMonth, monthQuery, setMonthQuery } = useMonth();
+  // use useEffect hook that only runs once to prevent infinite rerender for monthQuery.
   useEffect(() => {
     if (monthQuery === '') {
       setMonthQuery((new Date().getMonth() + 1).toString());

--- a/src/views/donationItemView/index.tsx
+++ b/src/views/donationItemView/index.tsx
@@ -81,7 +81,7 @@ export default function DonationItemView({ donations }: DonationItemProps) {
     if (monthQuery === '') {
       setMonthQuery((new Date().getMonth() + 1).toString());
     }
-  }, []);
+  }, [monthQuery, setMonthQuery]);
   // const [selectedMonth, setSelectedMonth] = useState<string>(
   //   (new Date().getMonth() + 1).toString() // Default to current month
   // );


### PR DESCRIPTION
# Description
Problem: Page updates monthQuery if monthQuery is an empty string, causes a state update every time the component renders with an empty monthQuery, leading directly into another render. 
FIx:  useEffect hook that only runs once.

## Relevant issue(s)
MoH - /donationItem` page error
[#11](https://github.com/hack4impact-utk/Maintenance-Team/issues/11)

<!-- For example:
https://jam.dev/c/5b536589-17d7-4717-a1d5-d408e1f00203

## Questions

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
