### PR TITLE
Fix receipt text overlaps with placeholder text

### DIFF
--- a/src/views/AddDonationView/index.tsx
+++ b/src/views/AddDonationView/index.tsx
@@ -375,6 +375,10 @@ export default function AddDonationView({
                     });
                   }
                 }}
+                InputLabelProps={{
+                  // Ensures the label floats when a value is present
+                  shrink: !!donationData.receipt,
+                }}
                 InputProps={{
                   endAdornment: (
                     <GenerateReceiptButton


### PR DESCRIPTION
# Description
Add a property-checking condition to shrink the placeholder when there is an input value, so it does not overlap with the value generated by the button.

## Relevant issue(s)
- https://github.com/hack4impact-utk/Maintenance-Team/issues/18

## Testing
- Run the page and look
- Click GeneratingButton many times
- Manually input some value
- Resize the windows to ensure compatibility

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
