### PR TITLE
MoH - Profile picture button jumps on click #27

### DIFF
--- a/src/components/AccountMenu/index.tsx
+++ b/src/components/AccountMenu/index.tsx
@@ -50,9 +50,6 @@ export default function AccountMenu() {
         open={Boolean(anchorEl)}
         onClose={handleClose}
         disableScrollLock // Prevents MUI from managing scroll behavior
-        MenuListProps={{
-          'aria-labelledby': 'account-menu-button',
-        }}
       >
         <MenuItem onClick={handleNavigateToPages}>
           <Link href="/signin" underline="none" color="#000">

--- a/src/components/AccountMenu/index.tsx
+++ b/src/components/AccountMenu/index.tsx
@@ -49,6 +49,10 @@ export default function AccountMenu() {
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handleClose}
+        disableScrollLock // Prevents MUI from managing scroll behavior
+        MenuListProps={{
+          'aria-labelledby': 'account-menu-button',
+        }}
       >
         <MenuItem onClick={handleNavigateToPages}>
           <Link href="/signin" underline="none" color="#000">


### PR DESCRIPTION
# Description
Disable the button from accessing the scroll button.

## Relevant issue(s)
- MoH - Profile picture button jumps on click
[#27](https://github.com/hack4impact-utk/Maintenance-Team/issues/27)

## Questions


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
