### PR TITLE
Saveable email templates - prevent duplicate email templates

### DIFF
--- a/src/app/api/mailMerge/route.ts
+++ b/src/app/api/mailMerge/route.ts
@@ -1,9 +1,4 @@
-import {
-  createMailMerge,
-  getAllMailMerge,
-  getMailMergeByType,
-  updateMailMerge,
-} from '@/server/actions/mailMerge';
+import { getAllMailMerge, upsertMailMerge } from '@/server/actions/mailMerge';
 import { zCreateMailMergeRequest } from '@/types/mailMerge';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -21,16 +16,9 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    try {
-      // Try to update
-      let res = await getMailMergeByType(validationResult.data.type);
-      res = await updateMailMerge(res._id, validationResult.data);
-      return NextResponse.json({ _id: res._id }, { status: 200 });
-    } catch {
-      // If no document found, create instead
-      const res = await createMailMerge(validationResult.data);
-      return NextResponse.json({ _id: res._id }, { status: 201 });
-    }
+    const [res, updated] = await upsertMailMerge(validationResult.data);
+
+    return NextResponse.json({ _id: res._id }, { status: updated ? 200 : 201 });
   } catch {
     return NextResponse.json({ message: 'Unknown Error' }, { status: 500 });
   }

--- a/src/server/actions/mailMerge.ts
+++ b/src/server/actions/mailMerge.ts
@@ -1,6 +1,10 @@
 import dbConnect from '@/utils/db-connect';
 import MailMergeSchema from '../models/mailMerge';
-import { CreateMailMergeRequest, MailMergeResponse } from '@/types/mailMerge';
+import {
+  CreateMailMergeRequest,
+  MailMergeResponse,
+  UpdateMailMergeRequest,
+} from '@/types/mailMerge';
 
 export async function getAllMailMerge(): Promise<MailMergeResponse[]> {
   try {
@@ -14,12 +18,37 @@ export async function getAllMailMerge(): Promise<MailMergeResponse[]> {
   }
 }
 
+export async function getMailMergeByType(
+  type: string
+): Promise<MailMergeResponse> {
+  await dbConnect();
+
+  const response = await MailMergeSchema.findOne({ type: type });
+
+  if (!response) throw Error('Document not found');
+
+  return response;
+}
+
 export async function createMailMerge(
   mailMerge: CreateMailMergeRequest
 ): Promise<MailMergeResponse> {
   await dbConnect();
 
   const response: MailMergeResponse = await MailMergeSchema.create(mailMerge);
+
+  return response;
+}
+
+export async function updateMailMerge(
+  id: string,
+  update: UpdateMailMergeRequest
+): Promise<MailMergeResponse> {
+  await dbConnect();
+
+  const response = await MailMergeSchema.findByIdAndUpdate(id, update);
+
+  if (!response) throw Error('Document not found');
 
   return response;
 }

--- a/src/types/mailMerge.ts
+++ b/src/types/mailMerge.ts
@@ -15,9 +15,14 @@ export const zCreateMailMergeRequest = zMailMergeBase;
 
 export const zMailMergeResponse = zMailMergeEntity;
 
+export const zUpdateMailMergeRequest = zCreateMailMergeRequest.partial();
+
 export interface MailMergeEntity extends z.infer<typeof zMailMergeEntity> {}
 
 export interface CreateMailMergeRequest
   extends z.infer<typeof zCreateMailMergeRequest> {}
 
 export interface MailMergeResponse extends z.infer<typeof zMailMergeResponse> {}
+
+export interface UpdateMailMergeRequest
+  extends z.infer<typeof zUpdateMailMergeRequest> {}

--- a/src/types/mailMerge.ts
+++ b/src/types/mailMerge.ts
@@ -15,14 +15,9 @@ export const zCreateMailMergeRequest = zMailMergeBase;
 
 export const zMailMergeResponse = zMailMergeEntity;
 
-export const zUpdateMailMergeRequest = zCreateMailMergeRequest.partial();
-
 export interface MailMergeEntity extends z.infer<typeof zMailMergeEntity> {}
 
 export interface CreateMailMergeRequest
   extends z.infer<typeof zCreateMailMergeRequest> {}
 
 export interface MailMergeResponse extends z.infer<typeof zMailMergeResponse> {}
-
-export interface UpdateMailMergeRequest
-  extends z.infer<typeof zUpdateMailMergeRequest> {}


### PR DESCRIPTION
# Description

- Replaced `/api/mailMerge` POST endpoint with PUT endpoint
- Replaced `createMailMerge()` server func with `upsertMailMerge()` in `/server/actions/mailMerge.ts`

Calls to the PUT endpoint will create a new document if there isn't one for the given mailType (receipt, monthly, yearly). If there is one, it will be updated. If there are multiple, the first is updated. Response is 201 if a new document is created, 200 if not.

## Relevant issue(s)

https://github.com/hack4impact-utk/Maintenance-Team/issues/29

## Testing

To verify that the feature works, send PUT requests with these bodies and check the database between each.
```
{
    "type": "Monthly",
    "subject": "Test Subject",
    "body": "Test Body"
}
```
```
{
    "type": "Monthly",
    "subject": "Test Subject 2",
    "body": "Test Body 2"
}
```
```
{
    "type": "Yearly",
    "subject": "Test Subject 2",
    "body": "Test Body 2"
}
```

The first should create a new document, the second should update it with the new subject and body (since it has the same type), and the third should create another new document (since it has a different type).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
