### PR TITLE
Fix add donation form not adding donations

### DIFF
--- a/src/views/AddDonationView/index.tsx
+++ b/src/views/AddDonationView/index.tsx
@@ -236,6 +236,7 @@ export default function AddDonationView({
   };
 
   const addDonation = async (createDonation: CreateDonationRequest) => {
+    donationData.prevDonated = prevDonated;
     const errors = validateDonation(donationData);
     if (errors) {
       setValidationErrors(errors);


### PR DESCRIPTION
# Description
Add donation form was adding donors and donation items when appropriate, but not donations. This was because the form data was being validated, but the `prevDonated` field was never set. This has been fixed.

## Relevant issue(s)

https://github.com/hack4impact-utk/Maintenance-Team/issues/32

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
