### PR TITLE
Clear Receipt field on donation submission

### DIFF
--- a/src/views/AddDonationView/index.tsx
+++ b/src/views/AddDonationView/index.tsx
@@ -105,6 +105,7 @@ export default function AddDonationView({
       setDonationItemFormDatas([{} as DonationItemFormData]);
       setDonationFormData({
         donationDate: new Date(),
+        receipt: '',
       } as DonationFormData);
     } catch (error) {
       showSnackbar(`Error:'${error}`, 'error');


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
Added clearing for the "Receipt" field when the "Submit Donation" button is pressed. Fixed by setting the receipt field to '' on a successful submission.

## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->
- hack4impact-utk/Maintenance-Team#46

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->
I noticed this issue was rated as a 2 even though I think it's just a 1 line fix, so just wanted to make sure I wasn't missing anything. I tested to ensure that the Receipt field is cleared both when manually typed and when auto-generated, and then verified the data to make sure that the Receipt # being entered into the DB was correct.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
