### PR TITLE
MoH - #45 - Clear high/low evaluation value from dropdown when clearing item/category

### DIFF
--- a/src/components/donationItemForm/index.tsx
+++ b/src/components/donationItemForm/index.tsx
@@ -74,24 +74,19 @@ export default function DonationItemForm({
     }
   });
 
-  // Checking undefined, null, and emptiness before show the Higg/Low values
-  const updateHighLowVals = (
-    newOrUsed: string,
-    value: undefined | ItemResponse
-  ) => {
-    if (newOrUsed === 'Used' && typeof value === 'undefined') {
+  // Show/clear the High/Low values based on existence of the ItemResponse
+  const updateHighLowVals = (newOrUsed: string, itemRes?: ItemResponse) => {
+    if (newOrUsed === 'Used' && itemRes) {
+      setHighLowVals([`High ($${itemRes?.high})`, `Low ($${itemRes?.low})`]);
+    } else if (newOrUsed === 'Used') {
       setHighLowVals(['High', 'Low']);
-    } else if (newOrUsed === 'Used' && typeof value !== 'undefined') {
-      setHighLowVals([`High ($${value?.high})`, `Low ($${value?.low})`]);
     }
   };
 
   const handleItemSelect = (name: string | ItemResponse) => {
     if (typeof name === 'string') {
       onChange({ ...donationItemData, name: name });
-      if (!name.trim().length) {
-        updateHighLowVals(donationItemData.newOrUsed, undefined);
-      }
+      updateHighLowVals(donationItemData.newOrUsed);
     } else {
       onChange({ ...donationItemData, name: name.name, itemRes: name });
       updateHighLowVals(donationItemData.newOrUsed, name);
@@ -101,9 +96,7 @@ export default function DonationItemForm({
   const handleCategorySelect = (category: string | ItemResponse) => {
     if (typeof category === 'string') {
       onChange({ ...donationItemData, category: category });
-      if (!category.trim().length) {
-        updateHighLowVals(donationItemData.newOrUsed, undefined);
-      }
+      updateHighLowVals(donationItemData.newOrUsed);
     } else {
       onChange({
         ...donationItemData,

--- a/src/components/donationItemForm/index.tsx
+++ b/src/components/donationItemForm/index.tsx
@@ -77,20 +77,20 @@ export default function DonationItemForm({
   // Checking undefined, null, and emptiness before show the Higg/Low values
   const updateHighLowVals = (
     newOrUsed: string,
-    value: string | ItemResponse
+    value: undefined | ItemResponse
   ) => {
-    if (newOrUsed === 'Used' && typeof value === 'string') {
+    if (newOrUsed === 'Used' && typeof value === 'undefined') {
       setHighLowVals(['High', 'Low']);
-    } else if (newOrUsed === 'Used' && typeof value !== 'string') {
-      setHighLowVals([`High ($${value.high})`, `Low ($${value.low})`]);
+    } else if (newOrUsed === 'Used' && typeof value !== 'undefined') {
+      setHighLowVals([`High ($${value?.high})`, `Low ($${value?.low})`]);
     }
   };
 
   const handleItemSelect = (name: string | ItemResponse) => {
     if (typeof name === 'string') {
       onChange({ ...donationItemData, name: name });
-      if (name.trim().length < 1) {
-        updateHighLowVals(donationItemData.newOrUsed, '');
+      if (!name.trim().length) {
+        updateHighLowVals(donationItemData.newOrUsed, undefined);
       }
     } else {
       onChange({ ...donationItemData, name: name.name, itemRes: name });
@@ -101,8 +101,8 @@ export default function DonationItemForm({
   const handleCategorySelect = (category: string | ItemResponse) => {
     if (typeof category === 'string') {
       onChange({ ...donationItemData, category: category });
-      if (category.trim().length < 1) {
-        updateHighLowVals(donationItemData.newOrUsed, '');
+      if (!category.trim().length) {
+        updateHighLowVals(donationItemData.newOrUsed, undefined);
       }
     } else {
       onChange({

--- a/src/components/donationItemForm/index.tsx
+++ b/src/components/donationItemForm/index.tsx
@@ -57,13 +57,6 @@ export default function DonationItemForm({
     'Low',
   ]);
 
-  // Checking undefined, null, and emptiness before show the Higg/Low values
-  const updateHighLowVals = (newOrUsed: string, itemRes: ItemResponse) => {
-    if (newOrUsed === 'Used') {
-      setHighLowVals([`High ($${itemRes.high})`, `Low ($${itemRes.low})`]);
-    }
-  };
-
   useEffect(() => {
     if (donationItemData.newOrUsed === 'Used') {
       if (donationItemData.highOrLow === 'High') {
@@ -81,9 +74,24 @@ export default function DonationItemForm({
     }
   });
 
+  // Checking undefined, null, and emptiness before show the Higg/Low values
+  const updateHighLowVals = (
+    newOrUsed: string,
+    value: string | ItemResponse
+  ) => {
+    if (newOrUsed === 'Used' && typeof value === 'string') {
+      setHighLowVals(['High', 'Low']);
+    } else if (newOrUsed === 'Used' && typeof value !== 'string') {
+      setHighLowVals([`High ($${value.high})`, `Low ($${value.low})`]);
+    }
+  };
+
   const handleItemSelect = (name: string | ItemResponse) => {
     if (typeof name === 'string') {
       onChange({ ...donationItemData, name: name });
+      if (name.trim().length < 1) {
+        updateHighLowVals(donationItemData.newOrUsed, '');
+      }
     } else {
       onChange({ ...donationItemData, name: name.name, itemRes: name });
       updateHighLowVals(donationItemData.newOrUsed, name);
@@ -93,6 +101,9 @@ export default function DonationItemForm({
   const handleCategorySelect = (category: string | ItemResponse) => {
     if (typeof category === 'string') {
       onChange({ ...donationItemData, category: category });
+      if (category.trim().length < 1) {
+        updateHighLowVals(donationItemData.newOrUsed, '');
+      }
     } else {
       onChange({
         ...donationItemData,


### PR DESCRIPTION
# Description
- Empty out the high/low evaluation value (ex. "High ($3.99)" -- the ($3.99) part of it) if the item or category is altered or removed.

## Relevant issue(s)
- https://github.com/hack4impact-utk/Maintenance-Team/issues/45

## Testing
- https://jam.dev/c/d93e8730-1e89-44b5-bf56-8dab7aaecc40

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
