### PR TITLE
28 saveable email templactes frontend implementation

### DIFF
--- a/src/app/api/mailMerge/route.ts
+++ b/src/app/api/mailMerge/route.ts
@@ -15,6 +15,7 @@ export async function PUT(request: NextRequest) {
         { status: 400 }
       );
     }
+    console.log(validationResult.data);
 
     const [res, updated] = await upsertMailMerge(validationResult.data);
 

--- a/src/app/api/mailMerge/route.ts
+++ b/src/app/api/mailMerge/route.ts
@@ -15,7 +15,6 @@ export async function PUT(request: NextRequest) {
         { status: 400 }
       );
     }
-    console.log(validationResult.data);
 
     const [res, updated] = await upsertMailMerge(validationResult.data);
 

--- a/src/app/mailMerge/page.tsx
+++ b/src/app/mailMerge/page.tsx
@@ -1,6 +1,14 @@
 import { getDonationItemById } from '@/server/actions/donationItem';
 import { getAllDonations } from '@/server/actions/donations';
+import { getAllMailMerge } from '@/server/actions/mailMerge';
+import { CreateMailMergeRequest, MailMergeResponse } from '@/types/mailMerge';
 import MailMergeView from '@/views/MailMergeView';
+
+function defaultTemplate(
+  type: 'Receipt' | 'Monthly' | 'Yearly'
+): CreateMailMergeRequest {
+  return { type: type, subject: '', body: '' };
+}
 
 export default async function MailMergePage() {
   const donations = JSON.parse(JSON.stringify(await getAllDonations()));
@@ -10,10 +18,26 @@ export default async function MailMergePage() {
     ),
   ];
 
+  const data: MailMergeResponse[] = JSON.parse(
+    JSON.stringify(await getAllMailMerge())
+  );
+  const templates = {
+    receipt:
+      data.find((response) => response['type'] == 'Receipt') ??
+      defaultTemplate('Receipt'),
+    monthly:
+      data.find((response) => response['type'] == 'Monthly') ??
+      defaultTemplate('Monthly'),
+    yearly:
+      data.find((response) => response['type'] == 'Yearly') ??
+      defaultTemplate('Yearly'),
+  };
+
   return (
     <MailMergeView
       exampleDonation={donations[0]}
       exampleDonationItems={donationItems}
+      templates={templates}
     />
   );
 }

--- a/src/components/email-editor/index.tsx
+++ b/src/components/email-editor/index.tsx
@@ -24,7 +24,7 @@ import useSnackbar from '@/hooks/useSnackbar';
 interface mailMergeProps {
   exampleDonation: DonationResponse;
   exampleDonationItems: DonationItemResponse[];
-  template?: { subject: string; body: string };
+  template: { type: string; subject: string; body: string };
 }
 
 export default function EmailEditor({
@@ -66,7 +66,7 @@ export default function EmailEditor({
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ subject, body }),
+        body: JSON.stringify({ type: template?.type, subject, body }),
       });
       showSnackbar('Email template saved', 'success');
     } catch (error) {

--- a/src/components/email-editor/index.tsx
+++ b/src/components/email-editor/index.tsx
@@ -25,14 +25,12 @@ interface mailMergeProps {
   exampleDonation: DonationResponse;
   exampleDonationItems: DonationItemResponse[];
   template?: { subject: string; body: string };
-  emailType?: string;
 }
 
 export default function EmailEditor({
   exampleDonation,
   exampleDonationItems,
   template,
-  emailType,
 }: mailMergeProps) {
   const ReactQuill = useMemo(
     () => dynamic(() => import('react-quill'), { ssr: false }),
@@ -61,39 +59,15 @@ export default function EmailEditor({
     setValue(newValue);
   };
 
-  const handleSaveButton = async () => {
-    // Validate input fields
-    if (!subject.trim() || !body.trim()) {
-      showSnackbar('Subject and body cannot be empty', 'error');
-      return;
-    }
-
-    // Ensure emailType is provided and is valid
-    const validEmailTypes = ['Receipt', 'Monthly', 'Yearly'];
-    if (!emailType || !validEmailTypes.includes(emailType)) {
-      showSnackbar('Invalid email type', 'error');
-      console.log(emailType);
-      return;
-    }
-
+  const handleSaveButton = () => {
     try {
-      const response = await fetch('/api/mailMerge', {
+      fetch('/api/mailMerge', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          type: emailType, // Use the correct type here
-          subject,
-          body,
-        }),
+        body: JSON.stringify({ subject, body }),
       });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.message || 'Error saving email template');
-      }
-
       showSnackbar('Email template saved', 'success');
     } catch (error) {
       showSnackbar('Error saving email template', 'error');

--- a/src/components/email-editor/index.tsx
+++ b/src/components/email-editor/index.tsx
@@ -19,6 +19,7 @@ import { DonationResponse, DonationItemResponse } from '@/types/donation';
 import { useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import mohColors from '@/utils/moh-theme';
+import useSnackbar from '@/hooks/useSnackbar';
 
 interface mailMergeProps {
   exampleDonation: DonationResponse;
@@ -36,6 +37,7 @@ export default function EmailEditor({
   const [body, setBody] = useState('');
   const [subject, setSubject] = useState('');
   const [value, setValue] = React.useState(0);
+  const { showSnackbar } = useSnackbar();
 
   const handleSubjectChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSubject(e.target.value);
@@ -47,6 +49,22 @@ export default function EmailEditor({
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
+  };
+
+  const handleSaveButton = () => {
+    try {
+      fetch('/api/mailMerge', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ subject, body }),
+      });
+      showSnackbar('Email template saved', 'success');
+    } catch (error) {
+      showSnackbar('Error saving email template', 'error');
+      throw error;
+    }
   };
 
   return (
@@ -139,6 +157,7 @@ export default function EmailEditor({
           variant="contained"
           sx={{ height: '40px' }}
           color="moh"
+          onClick={handleSaveButton}
           fullWidth
         >
           Send Email

--- a/src/components/email-editor/index.tsx
+++ b/src/components/email-editor/index.tsx
@@ -1,5 +1,13 @@
 'use client';
-import { Box, Card, Tab, Tabs, TextField, ThemeProvider } from '@mui/material';
+import {
+  Box,
+  Button,
+  Card,
+  Tab,
+  Tabs,
+  TextField,
+  ThemeProvider,
+} from '@mui/material';
 import { CustomTabPanel, ap } from '@/components/tab-panel';
 import { useState } from 'react';
 import 'react-quill/dist/quill.snow.css';
@@ -127,6 +135,14 @@ export default function EmailEditor({
             ></EmailParserCard>
           </CustomTabPanel>
         </Box>
+        <Button
+          variant="contained"
+          sx={{ height: '40px' }}
+          color="moh"
+          fullWidth
+        >
+          Send Email
+        </Button>
       </ThemeProvider>
     </>
   );

--- a/src/components/email-editor/index.tsx
+++ b/src/components/email-editor/index.tsx
@@ -9,7 +9,7 @@ import {
   ThemeProvider,
 } from '@mui/material';
 import { CustomTabPanel, ap } from '@/components/tab-panel';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import 'react-quill/dist/quill.snow.css';
 import EmailParserCard from '@/components/email-card';
 import QuillToolBar, { modules, formats } from '@/components/tool-bar';
@@ -24,11 +24,13 @@ import useSnackbar from '@/hooks/useSnackbar';
 interface mailMergeProps {
   exampleDonation: DonationResponse;
   exampleDonationItems: DonationItemResponse[];
+  template?: { subject: string; body: string };
 }
 
 export default function EmailEditor({
   exampleDonation,
   exampleDonationItems,
+  template,
 }: mailMergeProps) {
   const ReactQuill = useMemo(
     () => dynamic(() => import('react-quill'), { ssr: false }),
@@ -38,6 +40,12 @@ export default function EmailEditor({
   const [subject, setSubject] = useState('');
   const [value, setValue] = React.useState(0);
   const { showSnackbar } = useSnackbar();
+
+  useEffect(() => {
+    // Set the body and subject to the template if it exists
+    setBody(template?.body || '');
+    setSubject(template?.subject || '');
+  }, [template]);
 
   const handleSubjectChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSubject(e.target.value);

--- a/src/views/MailMergeView/index.tsx
+++ b/src/views/MailMergeView/index.tsx
@@ -20,6 +20,10 @@ export default function MailMergeView({
     setValue(newValue);
   };
 
+  //const displayEmailTemplate = () => {
+  // This function will display the email template
+  //}
+
   return (
     <Box sx={{ m: 1 }}>
       <Box sx={{ borderBottom: 0, borderColor: 'divider' }}>

--- a/src/views/MailMergeView/index.tsx
+++ b/src/views/MailMergeView/index.tsx
@@ -2,54 +2,28 @@
 import EmailEditor from '@/components/email-editor';
 import { CustomTabPanel, ap } from '@/components/tab-panel';
 import { DonationItemResponse, DonationResponse } from '@/types/donation';
-import { MailMergeResponse } from '@/types/mailMerge';
+import { CreateMailMergeRequest } from '@/types/mailMerge';
 import { Box, Tab, Tabs } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 interface mailMergeProps {
   exampleDonation: DonationResponse;
   exampleDonationItems: DonationItemResponse[];
+  templates: templates;
+}
+
+interface templates {
+  receipt: CreateMailMergeRequest;
+  monthly: CreateMailMergeRequest;
+  yearly: CreateMailMergeRequest;
 }
 
 export default function MailMergeView({
   exampleDonation,
   exampleDonationItems,
+  templates,
 }: mailMergeProps) {
   const [value, setValue] = React.useState(0);
-  const [templates, setTemplates] = useState<{ [key: string]: any }>({});
-
-  useEffect(() => {
-    const fetchTemplates = async () => {
-      try {
-        const response = await fetch('/api/mailMerge', {
-          method: 'GET',
-        });
-        const data: MailMergeResponse[] = await response.json();
-        const templateDict = {
-          receipt: data.find((response) => response['type'] == 'Receipt') ?? {
-            type: 'Receipt',
-            subject: '',
-            body: '',
-          },
-          monthly: data.find((response) => response['type'] == 'Monthly') ?? {
-            type: 'Receipt',
-            subject: '',
-            body: '',
-          },
-          yearly: data.find((response) => response['type'] == 'Yearly') ?? {
-            type: 'Yearly',
-            subject: '',
-            body: '',
-          },
-        };
-        setTemplates(templateDict);
-      } catch (error) {
-        console.error(error);
-      }
-    };
-
-    fetchTemplates();
-  }, []);
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
@@ -74,21 +48,21 @@ export default function MailMergeView({
         <EmailEditor
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
-          template={templates['receipt']}
+          template={templates.receipt}
         ></EmailEditor>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
         <EmailEditor
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
-          template={templates['monthly']}
+          template={templates.monthly}
         ></EmailEditor>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={2}>
         <EmailEditor
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
-          template={templates['yearly']}
+          template={templates.yearly}
         ></EmailEditor>
       </CustomTabPanel>
     </Box>

--- a/src/views/MailMergeView/index.tsx
+++ b/src/views/MailMergeView/index.tsx
@@ -58,7 +58,6 @@ export default function MailMergeView({
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
           template={templates['receipt']}
-          emailType="Receipt"
         ></EmailEditor>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
@@ -66,7 +65,6 @@ export default function MailMergeView({
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
           template={templates['monthly']}
-          emailType="Monthly"
         ></EmailEditor>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={2}>
@@ -74,7 +72,6 @@ export default function MailMergeView({
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
           template={templates['yearly']}
-          emailType="Yearly"
         ></EmailEditor>
       </CustomTabPanel>
     </Box>

--- a/src/views/MailMergeView/index.tsx
+++ b/src/views/MailMergeView/index.tsx
@@ -2,6 +2,7 @@
 import EmailEditor from '@/components/email-editor';
 import { CustomTabPanel, ap } from '@/components/tab-panel';
 import { DonationItemResponse, DonationResponse } from '@/types/donation';
+import { MailMergeResponse } from '@/types/mailMerge';
 import { Box, Tab, Tabs } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 
@@ -23,9 +24,25 @@ export default function MailMergeView({
         const response = await fetch('/api/mailMerge', {
           method: 'GET',
         });
-        const data = await response.json();
-        setTemplates(data);
-        // have to figure out how to set templates for each type
+        const data: MailMergeResponse[] = await response.json();
+        const templateDict = {
+          receipt: data.find((response) => response['type'] == 'Receipt') ?? {
+            type: 'Receipt',
+            subject: '',
+            body: '',
+          },
+          monthly: data.find((response) => response['type'] == 'Monthly') ?? {
+            type: 'Receipt',
+            subject: '',
+            body: '',
+          },
+          yearly: data.find((response) => response['type'] == 'Yearly') ?? {
+            type: 'Yearly',
+            subject: '',
+            body: '',
+          },
+        };
+        setTemplates(templateDict);
       } catch (error) {
         console.error(error);
       }

--- a/src/views/MailMergeView/index.tsx
+++ b/src/views/MailMergeView/index.tsx
@@ -3,7 +3,7 @@ import EmailEditor from '@/components/email-editor';
 import { CustomTabPanel, ap } from '@/components/tab-panel';
 import { DonationItemResponse, DonationResponse } from '@/types/donation';
 import { Box, Tab, Tabs } from '@mui/material';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface mailMergeProps {
   exampleDonation: DonationResponse;
@@ -15,14 +15,28 @@ export default function MailMergeView({
   exampleDonationItems,
 }: mailMergeProps) {
   const [value, setValue] = React.useState(0);
+  const [templates, setTemplates] = useState<{ [key: string]: any }>({});
+
+  useEffect(() => {
+    const fetchTemplates = async () => {
+      try {
+        const response = await fetch('/api/mailMerge', {
+          method: 'GET',
+        });
+        const data = await response.json();
+        setTemplates(data);
+        // have to figure out how to set templates for each type
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchTemplates();
+  }, []);
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
   };
-
-  //const displayEmailTemplate = () => {
-  // This function will display the email template
-  //}
 
   return (
     <Box sx={{ m: 1 }}>
@@ -43,18 +57,21 @@ export default function MailMergeView({
         <EmailEditor
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
+          template={templates['receipt']}
         ></EmailEditor>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
         <EmailEditor
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
+          template={templates['monthly']}
         ></EmailEditor>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={2}>
         <EmailEditor
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
+          template={templates['yearly']}
         ></EmailEditor>
       </CustomTabPanel>
     </Box>

--- a/src/views/MailMergeView/index.tsx
+++ b/src/views/MailMergeView/index.tsx
@@ -58,6 +58,7 @@ export default function MailMergeView({
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
           template={templates['receipt']}
+          emailType="Receipt"
         ></EmailEditor>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
@@ -65,6 +66,7 @@ export default function MailMergeView({
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
           template={templates['monthly']}
+          emailType="Monthly"
         ></EmailEditor>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={2}>
@@ -72,6 +74,7 @@ export default function MailMergeView({
           exampleDonation={exampleDonation}
           exampleDonationItems={exampleDonationItems}
           template={templates['yearly']}
+          emailType="Yearly"
         ></EmailEditor>
       </CustomTabPanel>
     </Box>


### PR DESCRIPTION
# Description
Email template editor is now populated with existing email templates. There is now a save button for each template which will save the contents of the email editor to the database by upserting with the current template type.

## Relevant issue(s)

https://github.com/hack4impact-utk/Maintenance-Team/issues/28

## To Test

Go to the page, type some stuff, press the save button, reload the page or check database and see that the stuff you wrote is now there.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
