### PR TITLE
 MoH - Send email on donation #30 

### DIFF
--- a/src/app/api/donations/route.ts
+++ b/src/app/api/donations/route.ts
@@ -34,15 +34,15 @@ export async function POST(request: NextRequest) {
     const donor = await getDonorById(result.donor);
     if (donor) {
       const receiptTemplate = (await getAllMailMerge()).find(
-        (value) => value.type == 'Receipt'
+        (value) => value.type === 'Receipt'
       );
       if (receiptTemplate) {
-        const thing = populateEmailTemplate(
+        const body = populateEmailTemplate(
           receiptTemplate.body,
           donor,
           result.entryDate
         );
-        await sendEmail([donor.email], receiptTemplate.subject, thing);
+        await sendEmail([donor.email], receiptTemplate.subject, body);
       }
     }
 

--- a/src/components/email-card/index.tsx
+++ b/src/components/email-card/index.tsx
@@ -2,6 +2,7 @@ import { Box, Card, Divider, Typography } from '@mui/material';
 import parse from 'html-react-parser';
 import { DonationResponse } from '@/types/donation';
 import { DonationItemResponse } from '@/types/donation';
+import { populateEmailTemplate } from '@/utils/string';
 
 interface emailProps {
   subjectLine: string;
@@ -15,28 +16,11 @@ export default function EmailParserCard({
   body,
   donation,
 }: emailProps) {
-  // const donor_regex = 'DONOR/i'
-  type repObj = {
-    FDONOR: string | undefined;
-    LDONOR: string;
-    DATE: string;
-  };
-  const entryDate = new Date(donation.entryDate);
-
-  const replaceObj: repObj = {
-    FDONOR: donation.donor.firstName,
-    LDONOR: donation.donor.lastName,
-    DATE: entryDate.toDateString(),
-  };
-
-  let key: keyof repObj;
-  let body_parse = body;
-
-  for (key in replaceObj) {
-    const replace = replaceObj[key];
-    if (replace === undefined) continue;
-    body_parse = body_parse.replaceAll(`[${key}]`, replace);
-  }
+  const body_parse = populateEmailTemplate(
+    body,
+    donation.donor,
+    donation.entryDate
+  );
 
   return (
     <Card sx={{ p: 2, pl: 9 }}>

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,31 @@
+import { DonorResponse } from '@/types/donors';
+
+// Perform a set of replacements on a string
+export function replaceMultiple(
+  str: string,
+  replacements: Map<string, string>
+): string {
+  let result: string = str;
+  replacements.forEach((replaceValue, searchValue) => {
+    result = result.replace(searchValue, replaceValue);
+  });
+  return result;
+}
+
+// Replace the email template placeholder values with the corresponding values from a donor and optionally a date
+export function populateEmailTemplate(
+  body: string,
+  donor: DonorResponse,
+  date?: Date
+): string {
+  const replacementMap = new Map<string, string>([
+    ['[LDONOR]', donor.lastName],
+  ]);
+  if (donor.firstName) {
+    replacementMap.set('[FDONOR]', donor.firstName);
+  }
+  if (date) {
+    replacementMap.set('[DATE]', date.toDateString());
+  }
+  return replaceMultiple(body, replacementMap);
+}

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -7,7 +7,7 @@ export function replaceMultiple(
 ): string {
   let result: string = str;
   replacements.forEach((replaceValue, searchValue) => {
-    result = result.replace(searchValue, replaceValue);
+    result = result.replaceAll(searchValue, replaceValue);
   });
   return result;
 }


### PR DESCRIPTION
# Description
Sends email to donor on adding donation.

## Relevant issue(s)

https://github.com/hack4impact-utk/Maintenance-Team/issues/30

## To Test

There is a bug currently that prevents the Add Donation page from adding a new donor, so you'll have to add/edit an existing donor to use your email address. Once you've done that, add a donation from that donor and you'll get an email. Edit the Receipt email template to use `[FDONOR]`, `[LDONOR]`, and/or `[DATE]` to test the placeholder text replacement.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
