### PR TITLE
MoH - display profile picture when logged in #39

### DIFF
--- a/src/components/AccountMenu/index.tsx
+++ b/src/components/AccountMenu/index.tsx
@@ -1,8 +1,10 @@
 'use client';
-import { Button, Link, Menu, MenuItem } from '@mui/material';
+import { Button, Link, Menu, MenuItem, Avatar } from '@mui/material';
 import { useState } from 'react';
+import { useSession } from 'next-auth/react';
 
 export default function AccountMenu() {
+  const { data: session } = useSession();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -30,19 +32,29 @@ export default function AccountMenu() {
         aria-haspopup="true"
         onClick={handleClick}
       >
-        <svg
-          width="56"
-          height="57"
-          viewBox="0 0 56 57"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M47.1841 45.8055C47.7698 45.6813 48.1181 45.0723 47.8818 44.5222C46.5492 41.42 44.084 38.6901 40.784 36.6855C37.1165 34.4576 32.6228 33.25 28 33.25C23.3772 33.25 18.8836 34.4576 15.216 36.6855C11.916 38.6901 9.45082 41.42 8.11826 44.5222C7.88197 45.0723 8.23024 45.6813 8.81589 45.8055L19.6996 48.1143C25.1723 49.2752 30.8277 49.2752 36.3004 48.1143L47.1841 45.8055Z"
-            fill="white"
-          />
-          <ellipse cx="27.9999" cy="19" rx="11.6667" ry="11.875" fill="white" />
-        </svg>
+        {session?.user?.image ? (
+          <Avatar alt={session.user.name || 'User'} src={session.user.image} />
+        ) : (
+          <svg
+            width="56"
+            height="57"
+            viewBox="0 0 56 57"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M47.1841 45.8055C47.7698 45.6813 48.1181 45.0723 47.8818 44.5222C46.5492 41.42 44.084 38.6901 40.784 36.6855C37.1165 34.4576 32.6228 33.25 28 33.25C23.3772 33.25 18.8836 34.4576 15.216 36.6855C11.916 38.6901 9.45082 41.42 8.11826 44.5222C7.88197 45.0723 8.23024 45.6813 8.81589 45.8055L19.6996 48.1143C25.1723 49.2752 30.8277 49.2752 36.3004 48.1143L47.1841 45.8055Z"
+              fill="white"
+            />
+            <ellipse
+              cx="27.9999"
+              cy="19"
+              rx="11.6667"
+              ry="11.875"
+              fill="white"
+            />
+          </svg>
+        )}
       </Button>
       <Menu
         id="account-menu"


### PR DESCRIPTION
# Description
Add profile picture to account bar.

- MoH - display profile picture when logged in
[#39](https://github.com/hack4impact-utk/Maintenance-Team/issues/39)

## Questions

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
