### PR TITLE
Removed 'edit' values from search

### DIFF
--- a/src/views/donationItemView/index.tsx
+++ b/src/views/donationItemView/index.tsx
@@ -106,8 +106,8 @@ export default function DonationItemView({ donations }: DonationItemProps) {
   );
 
   const formattedRows = uniqueDonationItems
-    .map((row) => ({
-      id: row._id,
+    .map((row, index) => ({
+      id: index + 1,
       product: row.item.name,
       category: row.item.category,
       quantity: row.quantity,
@@ -117,9 +117,11 @@ export default function DonationItemView({ donations }: DonationItemProps) {
       edit: row._id,
     }))
     .filter((row) =>
-      Object.values(row).some((value) =>
-        String(value).toLowerCase().includes(searchQuery.toLowerCase())
-      )
+      Object.entries(row)
+        .filter(([key]) => key !== 'edit') // Exclude 'edit' (row._id) value from search
+        .some((value) =>
+          String(value).toLowerCase().includes(searchQuery.toLowerCase())
+        )
     );
 
   return (

--- a/src/views/donorView/index.tsx
+++ b/src/views/donorView/index.tsx
@@ -57,9 +57,11 @@ export default function DonorView({ donors }: DonorViewProps) {
       };
     })
     .filter((row) =>
-      Object.values(row).some((value) =>
-        String(value).toLowerCase().includes(searchQuery.toLowerCase())
-      )
+      Object.entries(row)
+        .filter(([key]) => key !== 'edit') // Exclude 'edit' (donor._id) value from search
+        .some((value) =>
+          String(value).toLowerCase().includes(searchQuery.toLowerCase())
+        )
     );
 
   return (

--- a/src/views/itemView/index.tsx
+++ b/src/views/itemView/index.tsx
@@ -5,12 +5,15 @@ import { DataGrid, GridColDef, GridToolbar } from '@mui/x-data-grid';
 import { Container, IconButton, Typography } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import { ItemResponse } from '@/types/items';
+import useSearch from '@/hooks/useSearch';
 
 interface itemViewProps {
   items: ItemResponse[];
 }
 
 export default function ItemView({ items }: itemViewProps) {
+  const { searchString, searchQuery, setSearchQuery } = useSearch();
+
   const currency = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
@@ -65,14 +68,22 @@ export default function ItemView({ items }: itemViewProps) {
     },
   ];
 
-  const rows = items.map((item, index) => ({
-    id: index + 1,
-    name: item.name,
-    category: item.category,
-    high: item.high,
-    low: item.low,
-    edit: item._id,
-  }));
+  const rows = items
+    .map((item, index) => ({
+      id: index + 1,
+      name: item.name,
+      category: item.category,
+      high: item.high,
+      low: item.low,
+      edit: item._id,
+    }))
+    .filter((row) =>
+      Object.entries(row)
+        .filter(([key]) => key !== 'edit') // Exclude 'edit' (item._id) value from search
+        .some((value) =>
+          String(value).toLowerCase().includes(searchQuery.toLowerCase())
+        )
+    );
 
   return (
     <Container>
@@ -92,7 +103,13 @@ export default function ItemView({ items }: itemViewProps) {
           slotProps={{
             toolbar: {
               showQuickFilter: true,
-              quickFilterProps: { debounceMs: 500 }, // Optional: Configuring debounce
+              quickFilterProps: {
+                debounceMs: 100,
+                value: searchString,
+                onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+                  setSearchQuery(event.target.value);
+                },
+              },
             },
           }}
         />


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
Updated the search filters on the Inventory, Donors, and Evaluations page using the same fix implemented [here](https://github.com/hack4impact-utk/mission-of-hope/pull/227). Reasonably standardized some of the code to make the pages more similar to /DonationView (Ex: using useSearch on /ItemView, updating 'id' field on /DonationItemView).

## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->
- hack4impact-utk/Maintenance-Team#51

## Testing
if you don't want to hunt through the DB to find some _id values to test with, the 'edit' value still shows up in the export CSV's.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
