### PR TITLE
MoH Reorganize Sidenav #33

### DIFF
--- a/src/components/nav-bar/index.tsx
+++ b/src/components/nav-bar/index.tsx
@@ -20,8 +20,9 @@ import Image from 'next/image';
 export default function Navbar() {
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
 
+  // Expand or Collapse sub-buttons
   const handleToggle = (section: string) => {
-    setExpandedSection((prev) => (prev === section ? null : section)); // Toggle the clicked section
+    setExpandedSection((prev) => (prev === section ? null : section));
   };
 
   const buttonStyles: React.CSSProperties = {
@@ -78,18 +79,19 @@ export default function Navbar() {
       flexDirection="column"
       width="33vh" // Fix width of the navbar
       overflow="hidden" // Prevent any expanding overflow
-      bgcolor="white" // Set background color explicitly
       borderRight="1px solid #ddd"
     >
       {/* Logo Section */}
-      <Box display="flex" justifyContent="center" p={2}>
-        <Image
-          alt="logo"
-          src="/cropped-MOH-Logo-768x393.png"
-          width="200"
-          height="102"
-          className="rounded-md"
-        />
+      <Box display="flex" justifyContent="center">
+        <Button href="/">
+          <Image
+            alt="logo"
+            src="/cropped-MOH-Logo-768x393.png"
+            width="220"
+            height="107"
+            className="rounded-md"
+          />
+        </Button>
       </Box>
 
       {/* Button Groups */}

--- a/src/components/nav-bar/index.tsx
+++ b/src/components/nav-bar/index.tsx
@@ -26,11 +26,11 @@ export default function Navbar() {
 
   const buttonStyles: React.CSSProperties = {
     color: '#ff8a65',
-    fontSize: '16px',
+    fontSize: '15px',
     textTransform: 'none',
     justifyContent: 'flex-start',
     width: '100%',
-    padding: '12px 16px',
+    padding: '10px 10px',
   };
 
   const sections = [
@@ -76,7 +76,7 @@ export default function Navbar() {
       height="100vh"
       display="flex"
       flexDirection="column"
-      width="250px" // Fix width of the navbar
+      width="33vh" // Fix width of the navbar
       overflow="hidden" // Prevent any expanding overflow
       bgcolor="white" // Set background color explicitly
       borderRight="1px solid #ddd"
@@ -101,9 +101,9 @@ export default function Navbar() {
             startIcon={section.icon} // Add icon here
             endIcon={
               expandedSection === section.title ? (
-                <ExpandMore />
-              ) : (
                 <ExpandLess />
+              ) : (
+                <ExpandMore />
               )
             }
             style={{ ...buttonStyles, fontWeight: 'bold' }}
@@ -125,7 +125,7 @@ export default function Navbar() {
                   startIcon={btn.icon}
                   style={{
                     ...buttonStyles,
-                    paddingLeft: '32px', // Indent sub-buttons
+                    paddingLeft: '10px', // Indent sub-buttons
                     fontSize: '14px', // Smaller font for sub-buttons
                   }}
                 >

--- a/src/components/nav-bar/index.tsx
+++ b/src/components/nav-bar/index.tsx
@@ -1,157 +1,145 @@
-import Button from '@mui/material/Button';
-import Divider from '@mui/material/Divider';
-import { Box } from '@mui/material';
+'use client';
+
+import { useState } from 'react';
+import { Box, Button, Divider, Collapse } from '@mui/material';
+import {
+  AddBox,
+  Assignment,
+  Email,
+  Equalizer,
+  ExpandLess,
+  ExpandMore,
+  Group,
+  HandshakeRounded,
+  Inventory,
+  MiscellaneousServices,
+  VolunteerActivism,
+} from '@mui/icons-material';
 import Image from 'next/image';
 
-import HomeIcon from '@mui/icons-material/Home';
-import AddBoxIcon from '@mui/icons-material/AddBox';
-import AddCircleIcon from '@mui/icons-material/AddCircle';
-import VolunteerActivismIcon from '@mui/icons-material/VolunteerActivism';
-import BallotIcon from '@mui/icons-material/Ballot';
-import InventoryIcon from '@mui/icons-material/Inventory';
-import EqualizerIcon from '@mui/icons-material/Equalizer';
-import GroupIcon from '@mui/icons-material/Group';
-
 export default function Navbar() {
+  const [expandedSection, setExpandedSection] = useState<string | null>(null);
+
+  const handleToggle = (section: string) => {
+    setExpandedSection((prev) => (prev === section ? null : section)); // Toggle the clicked section
+  };
+
+  const buttonStyles: React.CSSProperties = {
+    color: '#ff8a65',
+    fontSize: '16px',
+    textTransform: 'none',
+    justifyContent: 'flex-start',
+    width: '100%',
+    padding: '12px 16px',
+  };
+
+  const sections = [
+    {
+      title: 'Donations',
+      icon: <VolunteerActivism />,
+      buttons: [
+        {
+          href: '/donation/add',
+          icon: <AddBox />,
+          label: 'Add Donation',
+        },
+        {
+          href: '/donation',
+          icon: <VolunteerActivism />,
+          label: 'Donations',
+        },
+        { href: '/donors', icon: <HandshakeRounded />, label: 'Donors' },
+      ],
+    },
+    {
+      title: 'Inventory',
+      icon: <Inventory />,
+      buttons: [
+        { href: '/donationItem', icon: <Inventory />, label: 'Inventory' },
+        { href: '/item/add', icon: <AddBox />, label: 'Add Evaluation' },
+        { href: '/item', icon: <Assignment />, label: 'Evaluations' },
+      ],
+    },
+    {
+      title: 'Reporting & Settings',
+      icon: <MiscellaneousServices />,
+      buttons: [
+        { href: '/mailMerge', icon: <Email />, label: 'Emails' },
+        { href: '/user', icon: <Group />, label: 'Users' },
+        { href: '#', icon: <Equalizer />, label: 'Reports' },
+      ],
+    },
+  ];
+
   return (
-    <>
-      <Box height={'100vh'}>
-        <Box display={'flex'} justifyContent={'center'} p={2}>
-          <Image
-            className="rounded-md"
-            alt="logo"
-            src="/cropped-MOH-Logo-768x393.png"
-            width="180"
-            height="100"
-            // style={{ marginRight: '25px' }} // Add spacing between the image and links
-          />
-        </Box>
-
-        <Box display={'flex'} justifyContent={'flex-start'} p={2}>
-          <Button
-            href="./"
-            startIcon={<HomeIcon />}
-            style={{
-              color: '#ff8a65',
-              fontSize: '25px',
-              textTransform: 'none',
-            }}
-          >
-            Home
-          </Button>
-        </Box>
-
-        <Box display={'flex'} justifyContent={'flex-start'} p={2}>
-          <Button
-            href="/donation/add"
-            startIcon={<AddCircleIcon />}
-            style={{
-              color: '#ff8a65',
-              fontSize: '25px',
-              textTransform: 'none',
-            }}
-          >
-            Add Donation
-          </Button>
-        </Box>
-
-        <Box display={'flex'} justifyContent={'flex-start'} p={2}>
-          <Button
-            href="/donation"
-            startIcon={<VolunteerActivismIcon />}
-            style={{
-              color: '#ff8a65',
-              fontSize: '25px',
-              textTransform: 'none',
-            }}
-          >
-            Donations
-          </Button>
-        </Box>
-
-        <Box display={'flex'} justifyContent={'flex-start'} p={2}>
-          <Button
-            href="/donors"
-            startIcon={<BallotIcon />}
-            style={{
-              color: '#ff8a65',
-              fontSize: '25px',
-              textTransform: 'none',
-            }}
-          >
-            Donors
-          </Button>
-        </Box>
-
-        <Box display={'flex'} justifyContent={'flex-start'} p={2}>
-          <Button
-            href="/donationItem"
-            startIcon={<InventoryIcon />}
-            style={{
-              color: '#ff8a65',
-              fontSize: '25px',
-              textTransform: 'none',
-            }}
-          >
-            Inventory
-          </Button>
-        </Box>
-
-        <Box display={'flex'} justifyContent={'flex-start'} p={2}>
-          <Button
-            href="/item/add"
-            startIcon={<AddBoxIcon />}
-            style={{
-              color: '#ff8a65',
-              fontSize: '25px',
-              textTransform: 'none',
-            }}
-          >
-            Add Evaluation
-          </Button>
-        </Box>
-        <Box display={'flex'} justifyContent={'flex-start'} p={2}>
-          <Button
-            href="/item"
-            startIcon={<BallotIcon />}
-            style={{
-              color: '#ff8a65',
-              fontSize: '25px',
-              textTransform: 'none',
-            }}
-          >
-            Evaluations
-          </Button>
-        </Box>
-
-        <Box display={'flex'} justifyContent={'flex-start'} p={2}>
-          <Button
-            href="./"
-            startIcon={<EqualizerIcon />}
-            style={{
-              color: '#ff8a65',
-              fontSize: '25px',
-              textTransform: 'none',
-            }}
-          >
-            Trends
-          </Button>
-        </Box>
-        <Box display={'flex'} justifyContent={'flex-start'} p={2}>
-          <Button
-            href="/user"
-            startIcon={<GroupIcon />}
-            style={{
-              color: '#ff8a65',
-              fontSize: '25px',
-              textTransform: 'none',
-            }}
-          >
-            Users
-          </Button>
-        </Box>
+    <Box
+      height="100vh"
+      display="flex"
+      flexDirection="column"
+      width="250px" // Fix width of the navbar
+      overflow="hidden" // Prevent any expanding overflow
+      bgcolor="white" // Set background color explicitly
+      borderRight="1px solid #ddd"
+    >
+      {/* Logo Section */}
+      <Box display="flex" justifyContent="center" p={2}>
+        <Image
+          alt="logo"
+          src="/cropped-MOH-Logo-768x393.png"
+          width="180"
+          height="100"
+          className="rounded-md"
+        />
       </Box>
+
+      {/* Button Groups */}
+      {sections.map((section, index) => (
+        <Box key={index} width="100%">
+          {/* Section Header */}
+          <Button
+            onClick={() => handleToggle(section.title)}
+            startIcon={section.icon} // Add icon here
+            endIcon={
+              expandedSection === section.title ? (
+                <ExpandMore />
+              ) : (
+                <ExpandLess />
+              )
+            }
+            style={{ ...buttonStyles, fontWeight: 'bold' }}
+          >
+            {section.title}
+          </Button>
+
+          {/* Sub-buttons (Expandable) */}
+          <Collapse
+            in={expandedSection === section.title} // Expand only the selected section
+            timeout="auto"
+            unmountOnExit
+          >
+            <Box display="flex" flexDirection="column" pl={2}>
+              {section.buttons.map((btn, btnIndex) => (
+                <Button
+                  key={btnIndex}
+                  href={btn.href}
+                  startIcon={btn.icon}
+                  style={{
+                    ...buttonStyles,
+                    paddingLeft: '32px', // Indent sub-buttons
+                    fontSize: '14px', // Smaller font for sub-buttons
+                  }}
+                >
+                  {btn.label}
+                </Button>
+              ))}
+            </Box>
+          </Collapse>
+          <Divider flexItem />
+        </Box>
+      ))}
+
+      {/* Vertical Divider */}
       <Divider orientation="vertical" flexItem />
-    </>
+    </Box>
   );
 }

--- a/src/components/nav-bar/index.tsx
+++ b/src/components/nav-bar/index.tsx
@@ -86,8 +86,8 @@ export default function Navbar() {
         <Image
           alt="logo"
           src="/cropped-MOH-Logo-768x393.png"
-          width="180"
-          height="100"
+          width="200"
+          height="102"
           className="rounded-md"
         />
       </Box>

--- a/src/components/nav-bar/index.tsx
+++ b/src/components/nav-bar/index.tsx
@@ -16,6 +16,7 @@ import {
   VolunteerActivism,
 } from '@mui/icons-material';
 import Image from 'next/image';
+import logo from '/public/cropped-MOH-Logo-768x393.png';
 
 export default function Navbar() {
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
@@ -27,7 +28,6 @@ export default function Navbar() {
 
   const buttonStyles: React.CSSProperties = {
     color: '#ff8a65',
-    fontSize: '15px',
     textTransform: 'none',
     justifyContent: 'flex-start',
     width: '100%',
@@ -73,66 +73,78 @@ export default function Navbar() {
   ];
 
   return (
-    <Box
-      height="100vh"
-      display="flex"
-      flexDirection="column"
-      width="33vh" // Fix width of the navbar
-      overflow="hidden" // Prevent any expanding overflow
-      borderRight="1px solid #ddd"
-    >
+    <Box flexDirection="column" height="100vh" borderRight="1px solid #ddd">
       {/* Logo Section */}
-      <Box display="flex" justifyContent="center">
+      <Box display="flex" justifyContent="center" p={2}>
         <Button href="/">
-          <Image
-            alt="logo"
-            src="/cropped-MOH-Logo-768x393.png"
-            width="220"
-            height="107"
-            className="rounded-md"
-          />
+          <Box
+            style={{
+              width: '100%', // Responsive width
+              maxWidth: '200px', // Increase this will make nav-bar wider but still responsive
+              display: 'flex',
+              justifyContent: 'center',
+            }}
+          >
+            <Image
+              priority={true}
+              alt="logo"
+              src={logo}
+              style={{
+                width: '100%',
+                height: 'auto',
+              }}
+              className="rounded-md"
+            />
+          </Box>
         </Button>
       </Box>
 
-      {/* Button Groups */}
+      {/* Section Groups */}
       {sections.map((section, index) => (
         <Box key={index} width="100%">
           {/* Section Header */}
           <Button
             onClick={() => handleToggle(section.title)}
-            startIcon={section.icon} // Add icon here
-            endIcon={
-              expandedSection === section.title ? (
-                <ExpandLess />
-              ) : (
-                <ExpandMore />
-              )
-            }
-            style={{ ...buttonStyles, fontWeight: 'bold' }}
+            style={{
+              ...buttonStyles,
+              fontWeight: 'bold',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              width: '100%',
+            }}
           >
-            {section.title}
+            {/* StartIcon and Text are left-alignment */}
+            <Box display="flex" alignItems="center" gap={1}>
+              {section.icon} {/* StartIcon */}
+              <span>{section.title}</span> {/* Button text */}
+            </Box>
+
+            {/* EndIcon is right-alignment */}
+            {expandedSection === section.title ? (
+              <ExpandLess />
+            ) : (
+              <ExpandMore />
+            )}
           </Button>
 
-          {/* Sub-buttons (Expandable) */}
-          <Collapse
-            in={expandedSection === section.title} // Expand only the selected section
-            timeout="auto"
-            unmountOnExit
-          >
+          {/* Expand only the selected subSection */}
+          <Collapse in={expandedSection === section.title}>
             <Box display="flex" flexDirection="column" pl={2}>
               {section.buttons.map((btn, btnIndex) => (
-                <Button
-                  key={btnIndex}
-                  href={btn.href}
-                  startIcon={btn.icon}
-                  style={{
-                    ...buttonStyles,
-                    paddingLeft: '10px', // Indent sub-buttons
-                    fontSize: '14px', // Smaller font for sub-buttons
-                  }}
-                >
-                  {btn.label}
-                </Button>
+                <Box key={btnIndex} width="100%">
+                  <Button
+                    key={btnIndex}
+                    href={btn.href}
+                    startIcon={btn.icon}
+                    style={{
+                      ...buttonStyles,
+                      marginLeft: '5%', // Indent sub-section
+                    }}
+                  >
+                    {btn.label}
+                  </Button>
+                </Box>
               ))}
             </Box>
           </Collapse>


### PR DESCRIPTION
# Description
- Separate the side Navbar button into groups
- Make the button text smaller and reduce the spacing between them
- Have the buttons have zero margin
- Make the logo clickable, navigating to default page '`/`'.

## Relevant issue(s)
- [Issue33](https://github.com/hack4impact-utk/Maintenance-Team/issues/33)

## Result
- [Jam Video](https://jam.dev/c/c3424d6d-7f4f-4cb3-b89c-bdeb300f7945)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
