### PR TITLE
Schema, server, and API support for modifying allowed users and admins

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,4 +1,5 @@
-import { getAllUsers } from '@/server/actions/users';
+import { getAllUsers, updateAllowedUsers } from '@/server/actions/users';
+import { zUpdateAllowedUsersRequest } from '@/types/users';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET() {
@@ -12,7 +13,19 @@ export async function GET() {
 
 export async function PUT(request: NextRequest) {
   try {
-    request;
+    // TODO: Authenticate permission to perform this action
+
+    const req = await request.json();
+    const validationResult = zUpdateAllowedUsersRequest.safeParse(req);
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { message: validationResult.error },
+        { status: 400 }
+      );
+    }
+
+    updateAllowedUsers(validationResult.data);
+    return new NextResponse(undefined, { status: 204 });
   } catch (e) {
     return NextResponse.json({ message: 'Unknown Error' }, { status: 500 });
   }

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,11 +1,19 @@
 import { getAllUsers } from '@/server/actions/users';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET() {
   try {
     const result = await getAllUsers();
     return NextResponse.json(result, { status: 200 });
   } catch {
+    return NextResponse.json({ message: 'Unknown Error' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    request;
+  } catch (e) {
     return NextResponse.json({ message: 'Unknown Error' }, { status: 500 });
   }
 }

--- a/src/server/actions/settings.ts
+++ b/src/server/actions/settings.ts
@@ -1,0 +1,21 @@
+import { SettingsResponse } from '@/types/settings';
+import dbConnect from '@/utils/db-connect';
+import Settings from '@/server/models/settings';
+
+export async function getSettings(): Promise<SettingsResponse> {
+  let settingsArr: SettingsResponse[] = [];
+
+  try {
+    await dbConnect();
+    settingsArr = await Settings.find({}).lean();
+
+    // there should always be exactly one settins object in the db
+    if (settingsArr.length !== 1) {
+      throw new Error('Must be exactly 1 settings object in database');
+    }
+  } catch (error) {
+    throw error;
+  }
+
+  return settingsArr[0];
+}

--- a/src/server/actions/users.ts
+++ b/src/server/actions/users.ts
@@ -1,6 +1,8 @@
 import UserSchema from '@/server/models/users';
-import { UserResponse } from '@/types/users';
+import { UpdateAllowedUsersRequest, UserResponse } from '@/types/users';
 import dbConnect from '@/utils/db-connect';
+import { getSettings } from './settings';
+import Settings from '@/server/models/settings';
 
 export async function getAllUsers(): Promise<UserResponse[]> {
   await dbConnect();
@@ -44,5 +46,29 @@ export async function addAdmins(userIds: string[]): Promise<void> {
     await UserSchema.updateMany({ _id: { $in: userIds } }, { isAdmin: true });
   } catch (error) {
     throw new Error('500 Admins could not be added');
+  }
+}
+
+export async function updateAllowedUsers(req: UpdateAllowedUsersRequest) {
+  try {
+    await dbConnect();
+
+    // if userEmails is not undefined, update allowed emails array
+    if (req.userEmails) {
+      const currentSettings = await getSettings();
+      await Settings.updateOne(
+        { _id: currentSettings._id },
+        { allowedEmails: req.userEmails }
+      );
+    }
+
+    // Should we remove user objects for emails that are no longer allowed?
+
+    //if adminIds is not undefined, flag included users as admin
+    if (req.adminIds) {
+      await addAdmins(req.adminIds);
+    }
+  } catch (error) {
+    throw error;
   }
 }

--- a/src/server/actions/users.ts
+++ b/src/server/actions/users.ts
@@ -35,3 +35,14 @@ export async function getUserByEmail(email: string): Promise<UserResponse> {
   }
   return user;
 }
+
+//
+export async function addAdmins(userIds: string[]): Promise<void> {
+  try {
+    await dbConnect();
+
+    await UserSchema.updateMany({ _id: { $in: userIds } }, { isAdmin: true });
+  } catch (error) {
+    throw new Error('500 Admins could not be added');
+  }
+}

--- a/src/server/models/settings.ts
+++ b/src/server/models/settings.ts
@@ -1,0 +1,44 @@
+import { SettingsEntity } from '@/types/settings';
+import { Model, Schema, model, models } from 'mongoose';
+
+const SettingsSchema = new Schema(
+  {
+    allowedEmails: {
+      type: [
+        {
+          type: String,
+          required: true,
+        },
+      ],
+    },
+  },
+  {
+    versionKey: false,
+    timestamps: true,
+  }
+);
+
+SettingsSchema.post('find', function (docs: SettingsEntity[]) {
+  docs.forEach((doc) => {
+    doc._id = doc._id.toString();
+  });
+});
+
+SettingsSchema.post('findOne', function (doc: SettingsEntity) {
+  if (doc) {
+    doc._id = doc._id.toString();
+  }
+});
+
+SettingsSchema.post(/findById/, function (doc: SettingsEntity) {
+  if (doc) {
+    doc._id = doc._id.toString();
+  }
+});
+
+export interface SettingsDocument
+  extends Omit<SettingsEntity, '_id'>,
+    Document {}
+
+export default (models.Settings as Model<SettingsDocument>) ||
+  model<SettingsDocument>('Settings', SettingsSchema, 'settings');

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import zBase from './base';
+
+const zSettings = z.object({
+  allowedEmails: z.array(z.string().email()),
+});
+
+const zSettingsEntity = zSettings.extend(zBase.shape);
+const zSettingsResponse = zSettingsEntity;
+
+export interface SettingsEntity extends z.infer<typeof zSettingsEntity> {}
+export interface SettingsResponse extends z.infer<typeof zSettingsResponse> {}

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,5 +1,6 @@
 import zBase from './base';
 import { z } from 'zod';
+import zObjectId from './objectId';
 
 export const zUserEntity = zBase.extend({
   name: z.string(),
@@ -10,6 +11,14 @@ export const zUserEntity = zBase.extend({
 
 export const zUserResponse = zUserEntity;
 
+export const zUpdateAllowedUsersRequest = z.object({
+  userEmails: z.array(z.string().email()).optional(),
+  adminIds: z.array(zObjectId).optional(),
+});
+
 export interface UserEntity extends z.infer<typeof zUserEntity> {}
 
 export interface UserResponse extends z.infer<typeof zUserResponse> {}
+
+export interface UpdateAllowedUsersRequest
+  extends z.infer<typeof zUpdateAllowedUsersRequest> {}


### PR DESCRIPTION
# Description

- Added Settings schema and zod types (currently just tracks allowed emails)
- Added server function to get settings
- Added server function and zod types to modify list of allowed users and which users are admins
- Added PUT endpoint to call these server functions

## Relevant issue(s)

https://github.com/hack4impact-utk/Maintenance-Team/issues/43

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have assigned reviewers to this PR
