### PR TITLE
User Dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "html-react-parser": "^5.1.10",
         "mongodb": "^5.9.1",
         "mongoose": "^7.4.5",
+        "mui-chips-input": "^2.1.4",
         "next": "13.4.19",
         "next-auth": "^4.24.7",
         "nodemailer": "^6.9.15",
@@ -3508,9 +3509,9 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3568,9 +3569,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5540,10 +5541,22 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
@@ -7140,6 +7153,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
     "node_modules/jsdom": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
@@ -7814,13 +7832,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.4.tgz",
-      "integrity": "sha512-kadPkS/f5iZJrrMxxOvSoOAErXmdnb28lMvHmuYgmV1ZQTpRqpp132PIPHkJMbG4OC2H0eSXYw/fNzYTH+LUcw==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.6.tgz",
+      "integrity": "sha512-1oVPRHvcmPVwk/zeSTEzayzQEVeYQM1D5zrkLsttfNNB7pPRUmkKeFu6gpbvyEswOuZLrWJjqB8kSTY+k2AZOA==",
       "dependencies": {
         "bson": "^5.5.0",
         "kareem": "2.5.1",
-        "mongodb": "5.9.0",
+        "mongodb": "5.9.2",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -7840,46 +7858,6 @@
       "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
       "engines": {
         "node": ">=14.20.1"
-      }
-    },
-    "node_modules/mongoose/node_modules/mongodb": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.0.tgz",
-      "integrity": "sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==",
-      "dependencies": {
-        "bson": "^5.5.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/saslprep": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.0.0",
-        "kerberos": "^1.0.0 || ^2.0.0",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
       }
     },
     "node_modules/mongoose/node_modules/ms": {
@@ -7911,10 +7889,29 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/mui-chips-input": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/mui-chips-input/-/mui-chips-input-2.1.4.tgz",
+      "integrity": "sha512-ysgY53fMO5q79znjBh/hW9TSy7c+nRs7sq7eEId8cdihimkDlQ40YaVzHvKhgUsU0McZ8OWE3guchtVdIl8HgA==",
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/icons-material": "^5.0.0",
+        "@mui/material": "^5.0.0",
+        "@types/react": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.9.tgz",
+      "integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==",
       "funding": [
         {
           "type": "github",
@@ -7981,13 +7978,13 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.8",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.8.tgz",
-      "integrity": "sha512-SLt3+8UCtklsotnz2p+nB4aN3IHNmpsQFAZ24VLxGotWGzSxkBh192zxNhm/J5wgkcrDWVp0bwqvW0HksK/Lcw==",
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.5.0",
+        "cookie": "^0.7.0",
         "jose": "^4.15.5",
         "oauth": "^0.9.15",
         "openid-client": "^5.4.0",
@@ -7997,10 +7994,10 @@
       },
       "peerDependencies": {
         "@auth/core": "0.34.2",
-        "next": "^12.2.5 || ^13 || ^14",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
         "nodemailer": "^6.6.5",
-        "react": "^17.0.2 || ^18",
-        "react-dom": "^17.0.2 || ^18"
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
       },
       "peerDependenciesMeta": {
         "@auth/core": {
@@ -9320,15 +9317,15 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "mongodb": "^5.9.1",
     "html-react-parser": "^5.1.10",
     "mongoose": "^7.4.5",
+    "mui-chips-input": "^2.1.4",
     "next": "13.4.19",
     "next-auth": "^4.24.7",
     "nodemailer": "^6.9.15",

--- a/src/app/api/admins/[userId]/remove/route.ts
+++ b/src/app/api/admins/[userId]/remove/route.ts
@@ -1,0 +1,24 @@
+import { removeAdmin } from '@/server/actions/users';
+import { zObjectId } from '@/types/objectId';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PUT(
+  _req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  try {
+    const validationResult = zObjectId.safeParse(params.userId);
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { message: validationResult.error },
+        { status: 400 }
+      );
+    }
+
+    await removeAdmin(params.userId);
+
+    return new NextResponse(undefined, { status: 204 });
+  } catch (e) {
+    return NextResponse.json({ message: 'Unknown Error' }, { status: 500 });
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,9 +1,9 @@
+import { getSettings } from '@/server/actions/settings';
+import { getAllUsers } from '@/server/actions/users';
 import SettingsView from '@/views/settingsView';
 
-export default function SettingsPage() {
-  return (
-    <>
-      <SettingsView></SettingsView>
-    </>
-  );
+export default async function SettingsPage() {
+  const users = await getAllUsers();
+  const settings = await getSettings();
+  return <SettingsView users={users} settings={settings}></SettingsView>;
 }

--- a/src/app/settings/users/page.tsx
+++ b/src/app/settings/users/page.tsx
@@ -5,5 +5,9 @@ import SettingsView from '@/views/settingsView';
 export default async function SettingsPage() {
   const users = await getAllUsers();
   const settings = await getSettings();
-  return <SettingsView users={users} settings={settings}></SettingsView>;
+  return (
+    <>
+      <SettingsView users={users} settings={settings}></SettingsView>
+    </>
+  );
 }

--- a/src/components/AccountMenu/index.tsx
+++ b/src/components/AccountMenu/index.tsx
@@ -3,7 +3,6 @@ import { Button, Link, Menu, MenuItem, Avatar } from '@mui/material';
 import { useState } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 
-
 export default function AccountMenu() {
   const { data: session } = useSession();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -67,11 +66,6 @@ export default function AccountMenu() {
         <MenuItem onClick={handleNavigateToPages}>
           <Link href="/signin" underline="none" color="#000">
             Login
-          </Link>
-        </MenuItem>
-        <MenuItem onClick={handleNavigateToPages}>
-          <Link href="/settings" underline="none" color="#000">
-            Settings
           </Link>
         </MenuItem>
         <MenuItem onClick={handleLogout}>Logout</MenuItem>

--- a/src/components/LoadingButton/index.tsx
+++ b/src/components/LoadingButton/index.tsx
@@ -1,0 +1,22 @@
+import { Button, ButtonProps, CircularProgress } from '@mui/material';
+
+interface LoadingButtonProps extends ButtonProps {
+  loading: boolean;
+  children?: React.ReactNode;
+  loadingSize?: number;
+}
+
+export default function LoadingButton({
+  loading,
+  loadingSize,
+  children,
+  ...buttonProps
+}: LoadingButtonProps) {
+  const disabled = loading || buttonProps?.disabled;
+  const size = loadingSize || 24;
+  return (
+    <Button {...buttonProps} disabled={disabled}>
+      {loading ? <CircularProgress size={`${size}px`} /> : children}
+    </Button>
+  );
+}

--- a/src/components/nav-bar/index.tsx
+++ b/src/components/nav-bar/index.tsx
@@ -66,7 +66,7 @@ export default function Navbar() {
       icon: <MiscellaneousServices />,
       buttons: [
         { href: '/mailMerge', icon: <Email />, label: 'Emails' },
-        { href: '/user', icon: <Group />, label: 'Users' },
+        { href: '/settings/users', icon: <Group />, label: 'Users' },
         { href: '#', icon: <Equalizer />, label: 'Reports' },
       ],
     },

--- a/src/server/actions/users.ts
+++ b/src/server/actions/users.ts
@@ -49,6 +49,16 @@ export async function addAdmins(userIds: string[]): Promise<void> {
   }
 }
 
+export async function removeAdmin(userId: string): Promise<void> {
+  try {
+    await dbConnect();
+
+    await UserSchema.updateOne({ _id: userId }, { isAdmin: false });
+  } catch (error) {
+    throw new Error('500 Admin could not be removed');
+  }
+}
+
 export async function updateAllowedUsers(req: UpdateAllowedUsersRequest) {
   try {
     await dbConnect();

--- a/src/views/settingsView/AdminAutocomplete/index.tsx
+++ b/src/views/settingsView/AdminAutocomplete/index.tsx
@@ -1,0 +1,37 @@
+import { UserResponse } from '@/types/users';
+import { Autocomplete, Avatar, Chip, TextField } from '@mui/material';
+
+interface AdminAutocompleteProps {
+  users: UserResponse[];
+  value?: UserResponse[];
+  onChange: (users: UserResponse[]) => void;
+}
+
+export default function AdminAutocomplete({
+  users,
+  value,
+  onChange,
+}: AdminAutocompleteProps) {
+  return (
+    <Autocomplete
+      multiple
+      options={users}
+      value={value}
+      isOptionEqualToValue={(option, value) => option._id === value._id}
+      getOptionLabel={(option) => option.name}
+      renderInput={(params) => <TextField {...params} label="Admins" />}
+      renderTags={(value, getTagProps) =>
+        value.map((option, index) => (
+          <Chip
+            avatar={<Avatar src={option.image || ''} />}
+            label={option.name}
+            {...getTagProps({ index })}
+            key={option._id}
+          />
+        ))
+      }
+      autoHighlight
+      onChange={(event, value) => onChange(value)}
+    ></Autocomplete>
+  );
+}

--- a/src/views/settingsView/UserList/index.tsx
+++ b/src/views/settingsView/UserList/index.tsx
@@ -1,0 +1,56 @@
+import { UserResponse } from '@/types/users';
+import { Clear } from '@mui/icons-material';
+import {
+  Avatar,
+  CircularProgress,
+  IconButton,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+} from '@mui/material';
+import { useState } from 'react';
+
+interface UserListProps {
+  users: UserResponse[];
+  onUserDelete: (user: UserResponse) => Promise<void>;
+}
+
+export default function UserList({ users, onUserDelete }: UserListProps) {
+  const [currentlyDeleting, setCurrentlyDeleting] = useState<string | null>(
+    null
+  );
+  return (
+    <List>
+      {/* Sorted by name */}
+      {users.map((user) => (
+        <ListItem
+          key={user._id}
+          secondaryAction={
+            <IconButton
+              edge="end"
+              aria-label="delete"
+              size="small"
+              onClick={async () => {
+                setCurrentlyDeleting(user._id);
+                await onUserDelete(user);
+                setCurrentlyDeleting(null);
+              }}
+            >
+              {currentlyDeleting === user._id ? (
+                <CircularProgress size={24} />
+              ) : (
+                <Clear fontSize="small" />
+              )}
+            </IconButton>
+          }
+        >
+          <ListItemAvatar>
+            <Avatar src={user.image || ''} />
+          </ListItemAvatar>
+          <ListItemText primary={user.name} secondary={user.email} />
+        </ListItem>
+      ))}
+    </List>
+  );
+}

--- a/src/views/settingsView/index.tsx
+++ b/src/views/settingsView/index.tsx
@@ -1,44 +1,151 @@
 'use client';
-import Grid2 from '@mui/material/Unstable_Grid2';
-import { Typography } from '@mui/material';
-import React from 'react';
+import { UserResponse } from '@/types/users';
+import UserList from './UserList';
+import { Box, Container, Typography } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
+import AdminAutocomplete from './AdminAutocomplete';
+import { useState } from 'react';
+import LoadingButton from '@/components/LoadingButton';
+import { SettingsResponse } from '@/types/settings';
+import { MuiChipsInput } from 'mui-chips-input';
+import { z } from 'zod';
+import useSnackbar from '@/hooks/useSnackbar';
+import { useRouter } from 'next/navigation';
 
-export default function SettingsView() {
+interface SettingsViewProps {
+  users: UserResponse[];
+  settings: SettingsResponse;
+}
+
+export default function SettingsView({ users, settings }: SettingsViewProps) {
+  const [newAdmins, setNewAdmins] = useState<UserResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [allowedEmails, setAllowedEmails] = useState(settings.allowedEmails);
+  const adminUsers = users.filter((user) => user.isAdmin);
+  const normalUsers = users.filter((user) => !user.isAdmin);
+  const { showSnackbar } = useSnackbar();
+  const router = useRouter();
+
+  const allowedEmailsDirty =
+    allowedEmails.join(',') !== settings.allowedEmails.join(',');
+
+  const updateSettings = async () => {
+    return await fetch('/api/users', {
+      method: 'PUT',
+      body: JSON.stringify({
+        userEmails: allowedEmails,
+        adminIds: newAdmins.map((user) => user._id),
+      }),
+    });
+  };
+
+  const handleSubmit = async () => {
+    try {
+      setIsLoading(true);
+      const res = await updateSettings();
+
+      if (!res.ok) {
+        showSnackbar('Failed to update settings', 'error');
+        return;
+      }
+
+      showSnackbar('Settings updated successfully', 'success');
+      // weird hack
+      router.refresh();
+      router.refresh();
+      setNewAdmins([]);
+    } catch (e) {
+      showSnackbar('Failed to update settings', 'error');
+      console.error('Failed to update settings', e);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleRemoveAdmin = async (user: UserResponse) => {
+    try {
+      const res = await fetch(`/api/admins/${user._id}/remove`, {
+        method: 'PUT',
+      });
+
+      if (!res.ok) {
+        showSnackbar('Failed to remove admin', 'error');
+        return;
+      }
+
+      showSnackbar('Admin removed successfully', 'success');
+      router.refresh();
+    } catch (e) {
+      showSnackbar('Failed to remove admin', 'error');
+      console.error('Failed to remove admin', e);
+    }
+  };
+
   return (
-    <Grid2 container>
-      <Grid2 xs={12} sx={{ mb: 3 }}>
-        <Typography variant="h3">Settings</Typography>
-      </Grid2>
-      <Grid2 xs={12}>
-        <Typography variant="h6">Admins</Typography>
-      </Grid2>
-
-      <Grid2 xs={12} md={6}>
-        should display list of admins
-      </Grid2>
-      <Grid2 xs={12} sx={{ mt: 2 }}>
-        <Typography variant="subtitle1">Add admins</Typography>
-      </Grid2>
-      <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
-        place to add admins
-      </Grid2>
-      <Grid2 xs={12} sx={{ mt: 3 }}>
-        <Typography variant="h6">Users</Typography>
-      </Grid2>
-      <Grid2 xs={12} sx={{ mt: 2 }}>
-        <Typography variant="subtitle1">Emails allowed to log in</Typography>
-      </Grid2>
-      <Grid2 xs={12}>
-        <Typography variant="caption" color="textSecondary">
-          placeholder
-        </Typography>
-      </Grid2>
-      <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
-        placeholder
-      </Grid2>
-      <Grid2 xs={12} sx={{ mt: 2 }}>
-        Save
-      </Grid2>
-    </Grid2>
+    <Container>
+      <Box sx={{ maxWidth: '73vw', height: '78vh' }}>
+        <Grid2 container>
+          <Grid2 xs={12} sx={{ mb: 3 }}>
+            <Typography variant="h3">Settings</Typography>
+          </Grid2>
+          <Grid2 xs={12}>
+            <Typography variant="h6">Admins</Typography>
+          </Grid2>
+          <Grid2 xs={12} md={6}>
+            <UserList users={adminUsers} onUserDelete={handleRemoveAdmin} />
+          </Grid2>
+          <Grid2 xs={12} sx={{ mt: 2 }}>
+            <Typography variant="subtitle1">Add admins</Typography>
+          </Grid2>
+          <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
+            <AdminAutocomplete
+              value={newAdmins}
+              users={normalUsers}
+              onChange={setNewAdmins}
+            />
+          </Grid2>
+          <Grid2 xs={12} sx={{ mt: 3 }}>
+            <Typography variant="h6">Users</Typography>
+          </Grid2>
+          <Grid2 xs={12} sx={{ mt: 2 }}>
+            <Typography variant="subtitle1">
+              Emails allowed to log in
+            </Typography>
+          </Grid2>
+          <Grid2 xs={12}>
+            <Typography variant="caption" color="textSecondary">
+              Emails ending with &quot;@compassionministries.net&quot; are
+              allowed automatically.
+            </Typography>
+          </Grid2>
+          <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
+            <MuiChipsInput
+              validate={(email) => {
+                const emailSchema = z.string().email();
+                return (
+                  emailSchema.safeParse(email).success &&
+                  !allowedEmails.includes(email)
+                );
+              }}
+              value={allowedEmails}
+              onChange={setAllowedEmails}
+              fullWidth
+              hideClearAll
+            />
+          </Grid2>
+          <Grid2 xs={12} sx={{ mt: 2 }}>
+            {/* TODO: update to loading button when ready */}
+            <LoadingButton
+              variant="contained"
+              onClick={handleSubmit}
+              disabled={newAdmins.length === 0 && !allowedEmailsDirty}
+              loading={isLoading}
+            >
+              Save
+            </LoadingButton>
+          </Grid2>
+        </Grid2>
+      </Box>
+    </Container>
   );
 }

--- a/src/views/settingsView/index.tsx
+++ b/src/views/settingsView/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { UserResponse } from '@/types/users';
 import UserList from './UserList';
-import { Box, Container, Typography } from '@mui/material';
+import { Box, Divider, ThemeProvider, Typography } from '@mui/material';
 import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
 import AdminAutocomplete from './AdminAutocomplete';
 import { useState } from 'react';
@@ -9,6 +9,7 @@ import LoadingButton from '@/components/LoadingButton';
 import { SettingsResponse } from '@/types/settings';
 import { MuiChipsInput } from 'mui-chips-input';
 import { z } from 'zod';
+import mohColors from '@/utils/moh-theme';
 import useSnackbar from '@/hooks/useSnackbar';
 import { useRouter } from 'next/navigation';
 
@@ -82,70 +83,80 @@ export default function SettingsView({ users, settings }: SettingsViewProps) {
   };
 
   return (
-    <Container>
-      <Box sx={{ maxWidth: '73vw', height: '78vh' }}>
-        <Grid2 container>
-          <Grid2 xs={12} sx={{ mb: 3 }}>
-            <Typography variant="h3">Settings</Typography>
-          </Grid2>
-          <Grid2 xs={12}>
-            <Typography variant="h6">Admins</Typography>
-          </Grid2>
-          <Grid2 xs={12} md={6}>
-            <UserList users={adminUsers} onUserDelete={handleRemoveAdmin} />
-          </Grid2>
-          <Grid2 xs={12} sx={{ mt: 2 }}>
-            <Typography variant="subtitle1">Add admins</Typography>
-          </Grid2>
-          <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
-            <AdminAutocomplete
-              value={newAdmins}
-              users={normalUsers}
-              onChange={setNewAdmins}
-            />
-          </Grid2>
-          <Grid2 xs={12} sx={{ mt: 3 }}>
-            <Typography variant="h6">Users</Typography>
-          </Grid2>
-          <Grid2 xs={12} sx={{ mt: 2 }}>
-            <Typography variant="subtitle1">
-              Emails allowed to log in
-            </Typography>
-          </Grid2>
-          <Grid2 xs={12}>
-            <Typography variant="caption" color="textSecondary">
-              Emails ending with &quot;@compassionministries.net&quot; are
-              allowed automatically.
-            </Typography>
-          </Grid2>
-          <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
-            <MuiChipsInput
-              validate={(email) => {
-                const emailSchema = z.string().email();
-                return (
-                  emailSchema.safeParse(email).success &&
-                  !allowedEmails.includes(email)
-                );
-              }}
-              value={allowedEmails}
-              onChange={setAllowedEmails}
-              fullWidth
-              hideClearAll
-            />
-          </Grid2>
-          <Grid2 xs={12} sx={{ mt: 2 }}>
-            {/* TODO: update to loading button when ready */}
-            <LoadingButton
-              variant="contained"
-              onClick={handleSubmit}
-              disabled={newAdmins.length === 0 && !allowedEmailsDirty}
-              loading={isLoading}
-            >
-              Save
-            </LoadingButton>
-          </Grid2>
-        </Grid2>
+    <ThemeProvider theme={mohColors}>
+      <Box display={'flex'} justifyContent={'center'}>
+        <Box
+          sx={{
+            padding: '20px',
+            margin: '20px',
+            border: '1px solid #00000030',
+            borderRadius: '10px',
+            width: '60vw',
+            boxShadow: '0px 4px 4px 0px #00000040',
+          }}
+        >
+          <Typography variant="h4" sx={{ mb: 2, ml: 2 }}>
+            User Settings
+          </Typography>
+          <Divider
+            sx={{
+              backgroundColor: '#379541',
+            }}
+          ></Divider>
+          <Box sx={{ mt: 1, pl: 2, pr: 2 }}>
+            <Grid2 xs={12}>
+              <Typography variant="h6">Admins</Typography>
+            </Grid2>
+            <Grid2 xs={12} md={6}>
+              <UserList users={adminUsers} onUserDelete={handleRemoveAdmin} />
+            </Grid2>
+            <Grid2 xs={12} sx={{ mt: 2 }}>
+              <Typography variant="subtitle1">Add admins</Typography>
+            </Grid2>
+            <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
+              <AdminAutocomplete
+                value={newAdmins}
+                users={normalUsers}
+                onChange={setNewAdmins}
+              />
+            </Grid2>
+            <Grid2 xs={12} sx={{ mt: 3 }}>
+              <Typography variant="h6">Users</Typography>
+            </Grid2>
+            <Grid2 xs={12} sx={{ mt: 2 }}>
+              <Typography variant="subtitle1">
+                Emails allowed to log in
+              </Typography>
+            </Grid2>
+            <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
+              <MuiChipsInput
+                validate={(email) => {
+                  const emailSchema = z.string().email();
+                  return (
+                    emailSchema.safeParse(email).success &&
+                    !allowedEmails.includes(email)
+                  );
+                }}
+                value={allowedEmails}
+                onChange={setAllowedEmails}
+                fullWidth
+                hideClearAll
+              />
+            </Grid2>
+            <Grid2 xs={12} sx={{ mt: 2 }}>
+              {/* TODO: update to loading button when ready */}
+              <LoadingButton
+                variant="contained"
+                onClick={handleSubmit}
+                disabled={newAdmins.length === 0 && !allowedEmailsDirty}
+                loading={isLoading}
+              >
+                Save
+              </LoadingButton>
+            </Grid2>
+          </Box>
+        </Box>
       </Box>
-    </Container>
+    </ThemeProvider>
   );
 }

--- a/src/views/settingsView/index.tsx
+++ b/src/views/settingsView/index.tsx
@@ -1,116 +1,44 @@
 'use client';
-import useSnackbar from '@/hooks/useSnackbar';
-import { Box, Button, Grid, TextField, Typography } from '@mui/material';
-import React, { useState } from 'react';
+import Grid2 from '@mui/material/Unstable_Grid2';
+import { Typography } from '@mui/material';
+import React from 'react';
 
 export default function SettingsView() {
-  const [userInfo, setUserInfo] = useState({
-    firstName: '',
-    lastName: '',
-    email: '',
-  });
-
-  const { showSnackbar } = useSnackbar();
-
-  const handleFirstNameChange = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setUserInfo({ ...userInfo, firstName: event.target.value });
-  };
-
-  const handleLastNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setUserInfo({ ...userInfo, lastName: event.target.value });
-  };
-
-  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setUserInfo({ ...userInfo, email: event.target.value });
-  };
-
-  // TODO: Create settings API endpoint
-  const handleSubmit = async () => {
-    try {
-      // Make an API call to update the user's information
-      const response = await fetch('/api/settings', {
-        method: 'PUT',
-        body: JSON.stringify({
-          firstName: userInfo.firstName,
-          lastName: userInfo.lastName,
-          email: userInfo.email,
-        }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-      if (!response.ok) {
-        showSnackbar('Failed to update user information', 'error');
-        throw new Error("Failed to update user's information");
-      }
-
-      const data = await response.json();
-      console.log(data); // TODO: Logging response data for now
-      showSnackbar('User information updated successfully', 'success');
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   return (
-    <Box
-      sx={{
-        padding: '20px',
-        margin: '20px',
-        border: '1px solid #00000030',
-        borderRadius: '10px',
-        width: '40%',
-        boxShadow: '0px 4px 4px 0px #00000040',
-      }}
-    >
-      <Typography variant="h4">Settings</Typography>
-      <Grid container spacing={1}>
-        <Grid item xs={6}>
-          <TextField
-            label="First Name"
-            variant="outlined"
-            value={userInfo.firstName}
-            onChange={handleFirstNameChange}
-            margin="normal"
-          />
-        </Grid>
-        <Grid item xs={6}>
-          <TextField
-            label="Last Name"
-            variant="outlined"
-            value={userInfo.lastName}
-            onChange={handleLastNameChange}
-            margin="normal"
-          />
-        </Grid>
-        <Grid item xs={11.2}>
-          <TextField
-            fullWidth
-            label="Email"
-            type="email"
-            variant="outlined"
-            value={userInfo.email}
-            onChange={handleEmailChange}
-            margin="normal"
-          />
-        </Grid>
-        {/* Admin boolean cannot be edited */}
-        <Button
-          type="submit"
-          variant="contained"
-          sx={{
-            backgroundColor: '#7ca86f',
-            color: 'white',
-            marginTop: '20px',
-            marginLeft: '10px',
-          }}
-          onClick={handleSubmit}
-        >
-          Save Changes
-        </Button>
-      </Grid>
-    </Box>
+    <Grid2 container>
+      <Grid2 xs={12} sx={{ mb: 3 }}>
+        <Typography variant="h3">Settings</Typography>
+      </Grid2>
+      <Grid2 xs={12}>
+        <Typography variant="h6">Admins</Typography>
+      </Grid2>
+
+      <Grid2 xs={12} md={6}>
+        should display list of admins
+      </Grid2>
+      <Grid2 xs={12} sx={{ mt: 2 }}>
+        <Typography variant="subtitle1">Add admins</Typography>
+      </Grid2>
+      <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
+        place to add admins
+      </Grid2>
+      <Grid2 xs={12} sx={{ mt: 3 }}>
+        <Typography variant="h6">Users</Typography>
+      </Grid2>
+      <Grid2 xs={12} sx={{ mt: 2 }}>
+        <Typography variant="subtitle1">Emails allowed to log in</Typography>
+      </Grid2>
+      <Grid2 xs={12}>
+        <Typography variant="caption" color="textSecondary">
+          placeholder
+        </Typography>
+      </Grid2>
+      <Grid2 xs={12} md={6} sx={{ mt: 1 }}>
+        placeholder
+      </Grid2>
+      <Grid2 xs={12} sx={{ mt: 2 }}>
+        Save
+      </Grid2>
+    </Grid2>
   );
 }


### PR DESCRIPTION
# Description

- Replaced old `/settings` page with dashboard for adding/removing admins and allowed emails. (EDIT: Also moved to `/settings/users`)
- Added server function and API route for removing an admin
- Added loading button component

## Relevant issue(s)

https://github.com/hack4impact-utk/Maintenance-Team/issues/41
(also went ahead and did backend)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## To test

Just go to `/settings` and add and remove stuff, it should work.

NOTE: Most of the current dummy user data in the database is wrong, so there'll be a bunch of empty lines in the add admin dropdown from those. The users with `name`, `email`, `image`, and `isAdmin` fields will show up correctly.

