### PR TITLE
MoH #34: Allow editable receipts

### DIFF
--- a/src/app/api/donations/[donationId]/route.ts
+++ b/src/app/api/donations/[donationId]/route.ts
@@ -1,11 +1,7 @@
 import { DonationResponse, zUpdateDonationRequest } from '@/types/donation';
-import { z } from 'zod';
+import { zObjectId } from '@/types/objectId';
 import { NextResponse, NextRequest } from 'next/server';
 import { updateDonation } from '../../../../server/actions/donations';
-
-const donationIdSchema = z
-  .string()
-  .regex(/^[a-fA-F0-9]{24}$/, 'Invalid donation ID format');
 
 export async function PUT(
   request: NextRequest,
@@ -13,7 +9,7 @@ export async function PUT(
 ) {
   try {
     // Parse and validate the string from the params
-    const validationId = donationIdSchema.safeParse(params.donationId);
+    const validationId = zObjectId.safeParse(params.donationId);
     if (!validationId.success) {
       return NextResponse.json({ error: validationId.error }, { status: 400 });
     }

--- a/src/app/api/donations/[donationId]/route.ts
+++ b/src/app/api/donations/[donationId]/route.ts
@@ -1,0 +1,41 @@
+import { DonationResponse } from '@/types/donation';
+import { NextResponse, NextRequest } from 'next/server';
+import { updateDonation } from '../../../../server/actions/donations';
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { donationId: string } }
+) {
+  if (!params || !params.donationId) {
+    return NextResponse.json(
+      { error: 'Invalid request, no donation ID provided' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // Parse the JSON body from the request
+    const updatedData = await request.json();
+
+    // Update the donation by id
+    const updatedDonation: DonationResponse | null = await updateDonation(
+      params.donationId,
+      updatedData
+    );
+
+    if (!updatedDonation) {
+      return NextResponse.json(
+        { error: 'Donation not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(updatedDonation, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json(
+      { error: 'Failed to update donation information', details: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/AccountMenu/index.tsx
+++ b/src/components/AccountMenu/index.tsx
@@ -3,6 +3,7 @@ import { Button, Link, Menu, MenuItem, Avatar } from '@mui/material';
 import { useState } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 
+
 export default function AccountMenu() {
   const { data: session } = useSession();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -63,22 +64,17 @@ export default function AccountMenu() {
         onClose={handleClose}
         disableScrollLock // Prevents MUI from managing scroll behavior
       >
-        {session?.user ? (
-          <>
-            <MenuItem onClick={handleNavigateToPages}>
-              <Link href="/settings" underline="none" color="#000">
-                Settings
-              </Link>
-            </MenuItem>
-            <MenuItem onClick={handleLogout}>Logout</MenuItem>
-          </>
-        ) : (
-          <MenuItem onClick={handleNavigateToPages}>
-            <Link href="/signin" underline="none" color="#000">
-              Login
-            </Link>
-          </MenuItem>
-        )}
+        <MenuItem onClick={handleNavigateToPages}>
+          <Link href="/signin" underline="none" color="#000">
+            Login
+          </Link>
+        </MenuItem>
+        <MenuItem onClick={handleNavigateToPages}>
+          <Link href="/settings" underline="none" color="#000">
+            Settings
+          </Link>
+        </MenuItem>
+        <MenuItem onClick={handleLogout}>Logout</MenuItem>
       </Menu>
     </>
   );

--- a/src/components/AccountMenu/index.tsx
+++ b/src/components/AccountMenu/index.tsx
@@ -3,7 +3,6 @@ import { Button, Link, Menu, MenuItem, Avatar } from '@mui/material';
 import { useState } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 
-
 export default function AccountMenu() {
   const { data: session } = useSession();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -64,17 +63,22 @@ export default function AccountMenu() {
         onClose={handleClose}
         disableScrollLock // Prevents MUI from managing scroll behavior
       >
-        <MenuItem onClick={handleNavigateToPages}>
-          <Link href="/signin" underline="none" color="#000">
-            Login
-          </Link>
-        </MenuItem>
-        <MenuItem onClick={handleNavigateToPages}>
-          <Link href="/settings" underline="none" color="#000">
-            Settings
-          </Link>
-        </MenuItem>
-        <MenuItem onClick={handleLogout}>Logout</MenuItem>
+        {session?.user ? (
+          <>
+            <MenuItem onClick={handleNavigateToPages}>
+              <Link href="/settings" underline="none" color="#000">
+                Settings
+              </Link>
+            </MenuItem>
+            <MenuItem onClick={handleLogout}>Logout</MenuItem>
+          </>
+        ) : (
+          <MenuItem onClick={handleNavigateToPages}>
+            <Link href="/signin" underline="none" color="#000">
+              Login
+            </Link>
+          </MenuItem>
+        )}
       </Menu>
     </>
   );

--- a/src/views/donationIdView/index.tsx
+++ b/src/views/donationIdView/index.tsx
@@ -34,7 +34,7 @@ export default function DonationIdView(props: donationProps) {
   const [donationFormData, setDonationFormData] = useState<DonationFormData>({
     donationDate: new Date(props.donation.entryDate),
     receipt: props.donation.receipt ?? '',
-    prevDonated: props.donation.entryDate ? true : false,
+    prevDonated: !!props.donation.entryDate,
   } as DonationFormData);
 
   const [donationItemFormData, setDonationItemFormData] = useState<
@@ -132,7 +132,7 @@ export default function DonationIdView(props: donationProps) {
         throw new Error('Failed to update donation');
       }
 
-      showSnackbar('Donation receipt updated successfully!', 'success');
+      showSnackbar('Donation updated successfully!', 'success');
     } catch (error) {
       showSnackbar(`Error updating donor: ${error}`, 'error');
     }


### PR DESCRIPTION
# Description
- I made the field Receipt editable and updatable. However, the `Receipt` number could be duplicated if the same number already exists (but it is out of scope for this task).
- I also created a new API file to update a donation using its ID: ./src/app/api/donations/[donationId]/route.ts.

## Relevant issue(s)
- [MoH - Allow editable receipts](https://github.com/hack4impact-utk/Maintenance-Team/issues/34)

## Note
- I did some edits to the **existing code** that is used to update the `Items` only:
  - I renamed some variables and functions, and added some comments to clarify them.
  - I have commented out the irrelevant code to turn off warnings because it is out-of-scope for this task.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - There is possible duplication `Receipt` numbers.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
