### PR TITLE
MoH #73: Disable the entire page and show loading circle while submitting

### DIFF
--- a/src/components/donation-form/AutofillDonorEmail.tsx
+++ b/src/components/donation-form/AutofillDonorEmail.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 interface Donor {
   DonorOptions: DonorResponse[];
   DonorForm: DonorFormData;
+  disable?: boolean;
   onDonorSelect: (donor: DonorResponse) => void;
   onChange: (donor: DonorFormData) => void;
   onClear: () => void;
@@ -32,6 +33,7 @@ export default function AutofillDonorEmail(props: Donor) {
   }
 
   function clear_form() {
+    if (props.disable) return;
     props.onChange({
       firstName: '',
       lastName: '',
@@ -51,11 +53,13 @@ export default function AutofillDonorEmail(props: Donor) {
       autoComplete
       value={props.DonorForm.email ?? ''}
       options={donorOptions}
+      disableClearable={props.disable}
+      disabled={props.disable}
       isOptionEqualToValue={(option, value) => option._id === value._id}
       getOptionLabel={(don) => (typeof don === 'string' ? don : don.email)}
-      renderOption={(props, option) => {
+      renderOption={(optionProps, option) => {
         return (
-          <li {...props} key={option._id}>
+          <li {...optionProps} key={option._id}>
             {option.email}
           </li>
         );
@@ -67,6 +71,11 @@ export default function AutofillDonorEmail(props: Donor) {
           id="outlined-required"
           value={''}
           type="email"
+          disabled={props.disable}
+          inputProps={{
+            ...params.inputProps,
+            readOnly: props.disable, // Prevents dropdown when disable
+          }}
         />
       )}
       onInputChange={(_, value) => {

--- a/src/components/generateReceiptButton/index.tsx
+++ b/src/components/generateReceiptButton/index.tsx
@@ -2,6 +2,7 @@ import { IconButton, Tooltip } from '@mui/material';
 import CachedIcon from '@mui/icons-material/Cached';
 
 interface receiptButtonProps {
+  disabled?: boolean;
   onChange: (receipt: Response) => void;
 }
 
@@ -19,7 +20,7 @@ export default function GenerateReceiptButton(props: receiptButtonProps) {
 
   return (
     <Tooltip title="Generate Receipt" placement="top">
-      <IconButton onClick={handleButton}>
+      <IconButton disabled={props.disabled} onClick={handleButton}>
         <CachedIcon></CachedIcon>
       </IconButton>
     </Tooltip>

--- a/src/views/AddDonationView/index.tsx
+++ b/src/views/AddDonationView/index.tsx
@@ -17,6 +17,7 @@ import {
   ThemeProvider,
   Tooltip,
   Typography,
+  CircularProgress,
 } from '@mui/material';
 import React, { useState } from 'react';
 import useSnackbar from '@/hooks/useSnackbar';
@@ -51,6 +52,7 @@ export default function AddDonationView({
   >([{} as DonationItemFormData] as DonationItemFormData[]);
   const [prevDonated, setPrevDonated] = useState(false);
   const [donorInfoFormDisabled, setDonorInfoFormDisabled] = useState(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false); // For the loading wheel
 
   const { validate: validateDonation } = useValidation(zDonationFormData);
   const { validate: validateDonor } = useValidation(zDonorFormData);
@@ -94,6 +96,7 @@ export default function AddDonationView({
   };
 
   const handleAddDonation = async () => {
+    setIsLoading(true);
     const createDonation: CreateDonationRequest = {
       entryDate: new Date(donationData.donationDate),
       user: '661dc544ed3579f193bb008c',
@@ -118,6 +121,8 @@ export default function AddDonationView({
       } as DonationFormData);
     } catch (error) {
       showSnackbar(`Error:'${error}`, 'error');
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -299,6 +304,7 @@ export default function AddDonationView({
               <AutofillDonorEmail
                 DonorOptions={donorOptions}
                 DonorForm={donorFormData}
+                disable={isLoading}
                 onDonorSelect={handleDonorSelect}
                 onChange={setDonorFormData}
                 onClear={() => setDonorInfoFormDisabled(false)}
@@ -310,6 +316,7 @@ export default function AddDonationView({
                 id="outlined-required"
                 label="Donation Date"
                 type="date"
+                disabled={isLoading}
                 value={
                   donationData?.donationDate?.toISOString()?.split('T')[0] || ''
                 }
@@ -329,7 +336,7 @@ export default function AddDonationView({
             <DonorForm
               donorData={donorFormData}
               onChange={setDonorFormData}
-              disabled={donorInfoFormDisabled}
+              disabled={donorInfoFormDisabled || isLoading}
             />
 
             <Grid item xs={12}>
@@ -338,6 +345,7 @@ export default function AddDonationView({
                 id="outlined-required"
                 label="Receipt"
                 value={donationData.receipt}
+                disabled={isLoading}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const re = /^[0-9\b]+$/;
                   // if value is not blank, then test the regex
@@ -355,6 +363,7 @@ export default function AddDonationView({
                 InputProps={{
                   endAdornment: (
                     <GenerateReceiptButton
+                      disabled={isLoading}
                       onChange={async (Res: Response) => {
                         if (Res.ok) {
                           const receipt = await Res.json();
@@ -394,7 +403,7 @@ export default function AddDonationView({
                     handleDonationItemFormChange(value, index)
                   }
                   key={index}
-                  disabled={false}
+                  disabled={isLoading}
                   // validationErrors={}
                 />
                 <Grid
@@ -407,6 +416,7 @@ export default function AddDonationView({
                 >
                   <Tooltip title="Remove">
                     <IconButton
+                      disabled={isLoading}
                       onClick={() => {
                         donationItemFormDatas.splice(index, 1);
                         setDonationItemFormDatas([...donationItemFormDatas]);
@@ -425,6 +435,7 @@ export default function AddDonationView({
                 variant="outlined"
                 startIcon={<AddIcon></AddIcon>}
                 color="moh"
+                disabled={isLoading}
                 onClick={() =>
                   setDonationItemFormDatas([
                     ...donationItemFormDatas,
@@ -443,9 +454,17 @@ export default function AddDonationView({
                 sx={{ height: '40px' }}
                 onClick={() => handleAddDonation()}
                 color="moh"
+                disabled={isLoading}
                 fullWidth
               >
-                Submit Donation
+                {isLoading ? (
+                  <CircularProgress
+                    size={30}
+                    color="inherit"
+                  ></CircularProgress>
+                ) : (
+                  'Submit Donation'
+                )}
               </Button>
             </Grid>
           </Grid>


### PR DESCRIPTION
# Description
- Disable all the fields and buttons while submitting on /donation/add page.
- Show a loading circle instead of "Submit Donation" text while submitting on /donation/add page.

## Relevant issue(s)
- [MoH#73](https://github.com/hack4impact-utk/Maintenance-Team/issues/73)

## Note
- I added the `disable` property for the **./src/components/donation-form/AutofillDonorEmail.tsx** so we can reuse it for other pages.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
