### PR TITLE
Prevent columns dropdown from closing on click on tables

### DIFF
--- a/src/views/AddDonationView/index.tsx
+++ b/src/views/AddDonationView/index.tsx
@@ -110,7 +110,7 @@ export default function AddDonationView({
       createDonation.items = (await addDonationItems()).map((item) => {
         return item._id;
       });
-      //Get user
+
       await addDonation(createDonation);
 
       setDonorFormData({} as DonorFormData);
@@ -120,7 +120,7 @@ export default function AddDonationView({
         receipt: '',
       } as DonationFormData);
     } catch (error) {
-      showSnackbar(`Error:'${error}`, 'error');
+      showSnackbar(`Error: '${error}`, 'error');
     } finally {
       setIsLoading(false);
     }

--- a/src/views/donationItemView/index.tsx
+++ b/src/views/donationItemView/index.tsx
@@ -71,6 +71,7 @@ const allColumns: GridColDef[] = [
 export default function DonationItemView({ donations }: DonationItemProps) {
   const { searchString, searchQuery, setSearchQuery } = useSearch();
   const { selectedMonth, monthQuery, setMonthQuery } = useMonth();
+  const [columnSelectorOpen, setColumnSelectorOpen] = useState<boolean>(false);
 
   const [visibleColumns, setVisibleColumns] = useState<string[]>(
     allColumns.map((col) => col.field)
@@ -173,6 +174,9 @@ export default function DonationItemView({ donations }: DonationItemProps) {
           <InputLabel></InputLabel>
           <Select
             multiple
+            open={columnSelectorOpen}
+            onOpen={() => setColumnSelectorOpen(true)}
+            onClose={() => setColumnSelectorOpen(false)}
             value={visibleColumns}
             onChange={handleColumnSelectionChange}
             renderValue={(selected) =>

--- a/src/views/donationView/index.tsx
+++ b/src/views/donationView/index.tsx
@@ -32,12 +32,14 @@ export default function DonationView({ donations }: DonationViewProps) {
   const { searchString, searchQuery, setSearchQuery } = useSearch();
   const { selectedYear, yearQuery, setYearQuery } = useYear();
   const { selectedMonth, monthQuery, setMonthQuery } = useMonth();
+  const [columnSelectorOpen, setColumnSelectorOpen] = useState<boolean>(false);
 
   const [visibleColumns, setVisibleColumns] = useState<string[]>([
     'donor',
     'quantity',
     'user_name',
     'date',
+    'receipt',
     'edit',
   ]);
 
@@ -123,6 +125,7 @@ export default function DonationView({ donations }: DonationViewProps) {
   );
 
   const handleColumnSelectionChange = (event: SelectChangeEvent<string[]>) => {
+    event.preventDefault();
     const selectedColumns = event.target.value as string[];
     setVisibleColumns(selectedColumns);
   };
@@ -141,6 +144,9 @@ export default function DonationView({ donations }: DonationViewProps) {
           <InputLabel></InputLabel>
           <Select
             multiple
+            open={columnSelectorOpen}
+            onOpen={() => setColumnSelectorOpen(true)}
+            onClose={() => setColumnSelectorOpen(false)}
             sx={{
               padding: '0px 6px',
               minWidth: 'auto',

--- a/src/views/donorView/index.tsx
+++ b/src/views/donorView/index.tsx
@@ -26,6 +26,7 @@ interface DonorViewProps {
 
 export default function DonorView({ donors }: DonorViewProps) {
   const { searchString, searchQuery, setSearchQuery } = useSearch();
+  const [columnSelectorOpen, setColumnSelectorOpen] = useState<boolean>(false);
 
   const [visibleColumns, setVisibleColumns] = useState<string[]>([
     'name',
@@ -139,6 +140,9 @@ export default function DonorView({ donors }: DonorViewProps) {
           <InputLabel></InputLabel>
           <Select
             multiple
+            open={columnSelectorOpen}
+            onOpen={() => setColumnSelectorOpen(true)}
+            onClose={() => setColumnSelectorOpen(false)}
             value={visibleColumns}
             onChange={handleColumnSelectionChange}
             renderValue={(selected) =>

--- a/src/views/itemView/index.tsx
+++ b/src/views/itemView/index.tsx
@@ -27,6 +27,8 @@ interface ItemViewProps {
 
 export default function ItemView({ items }: ItemViewProps) {
   const { searchString, searchQuery, setSearchQuery } = useSearch();
+  const [columnSelectorOpen, setColumnSelectorOpen] = useState<boolean>(false);
+
   const currency = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
@@ -158,6 +160,9 @@ export default function ItemView({ items }: ItemViewProps) {
           <InputLabel></InputLabel>
           <Select
             multiple
+            open={columnSelectorOpen}
+            onOpen={() => setColumnSelectorOpen(true)}
+            onClose={() => setColumnSelectorOpen(false)}
             value={visibleColumns}
             onChange={handleColumnSelectionChange}
             renderValue={(selected) =>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
Makes it so when you click an option on a table column selector, it will not minimize. It is multi select, so having to reopen it multiple times to select all the options you want was quite frustrating

## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->
[#67](https://github.com/hack4impact-utk/Maintenance-Team/issues/67)

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
