### PR TITLE
Fix adding new donor when adding donation

### DIFF
--- a/src/views/AddDonationView/index.tsx
+++ b/src/views/AddDonationView/index.tsx
@@ -77,7 +77,7 @@ export default function AddDonationView({
       setPrevDonated(true);
       setDonorInfoFormDisabled(true);
     } else {
-      setDonorFormData({} as DonorFormData); // Clear form when donor is deselected
+      setDonorFormData({ _id: '' } as DonorFormData); // Clear form when donor is deselected
       setDonorInfoFormDisabled(false);
       setPrevDonated(false);
     }


### PR DESCRIPTION
# Description
Submitting the Add Donation form no longer removes the `_id` field from the donor form data, which previously prevented adding a new donor through the form after submitting it the first time without reloading the page.

I'm pretty sure this fixed the issue, as I wasn't able to recreate it after the fix, but the add donation form code is a complete mess and there could still be some way to trigger the issue I didn't see.

## Relevant issue(s)

https://github.com/hack4impact-utk/Maintenance-Team/issues/52

## To test

Fill out and submit the Add Donation form. Then fill it out again without reloading, with the donor section containing info for a new donor. Submit it again, and it should add the new donor.