### PR TITLE
Created method to condense multiple entires of the same item into one…

### DIFF
--- a/src/types/donation.ts
+++ b/src/types/donation.ts
@@ -1,7 +1,7 @@
 import zBase from './base';
 import { z } from 'zod';
 import zObjectId from './objectId';
-import { zItemResponse } from './items';
+import { zItemResponse, ItemResponse } from './items';
 import { zUserResponse } from './users';
 import { zDonorResponse } from './donors';
 
@@ -68,3 +68,12 @@ export interface DonationResponse extends z.infer<typeof zDonationResponse> {}
 
 export interface UpdateDonationRequest
   extends z.infer<typeof zUpdateDonationRequest> {}
+
+export interface GroupedDonationItem {
+  item: ItemResponse;
+  quantity: number;
+  totalValue: number;
+  barcode?: string;
+  evaluation: string;
+  itemIds: string[];
+}

--- a/src/views/donationItemView/index.tsx
+++ b/src/views/donationItemView/index.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from 'react';
 import {
   Box,
-  Chip,
   Container,
   Grid,
   IconButton,
@@ -27,33 +26,33 @@ interface DonationItemProps {
 }
 
 const allColumns: GridColDef[] = [
-  { field: 'product', headerName: 'Product', maxWidth: 300, flex: 0.4 },
-  { field: 'category', headerName: 'Category', maxWidth: 300, flex: 0.4 },
-  { field: 'quantity', headerName: 'Quantity', maxWidth: 80, flex: 0.5 },
-  { field: 'evaluation', headerName: 'Evaluation', maxWidth: 80, flex: 0.5 },
-  {
-    field: 'barcode',
-    headerName: 'Barcode (if food)',
-    maxWidth: 200,
-    flex: 0.5,
-    renderCell: (params) =>
-      params.value ? (
-        <Chip
-          label={params.value}
-          sx={{
-            bgcolor: '#37954173',
-            border: 'solid',
-            borderColor: '#ABABAB',
-          }}
-        />
-      ) : null,
-  },
-  { field: 'price', headerName: 'Price', maxWidth: 100, flex: 0.5 },
+  { field: 'product', headerName: 'Product', maxWidth: 300, flex: 2 },
+  { field: 'category', headerName: 'Category', maxWidth: 300, flex: 2 },
+  { field: 'quantity', headerName: 'Quantity', maxWidth: 300, flex: 1 },
+  // { field: 'evaluation', headerName: 'Evaluation', maxWidth: 80, flex: 0.5 },
+  // {
+  //   field: 'barcode',
+  //   headerName: 'Barcode (if food)',
+  //   maxWidth: 200,
+  //   flex: 0.5,
+  //   renderCell: (params) =>
+  //     params.value ? (
+  //       <Chip
+  //         label={params.value}
+  //         sx={{
+  //           bgcolor: '#37954173',
+  //           border: 'solid',
+  //           borderColor: '#ABABAB',
+  //         }}
+  //       />
+  //     ) : null,
+  // },
+  { field: 'price', headerName: 'Value', flex: 1 },
   {
     field: 'edit',
     headerName: 'Edit',
     maxWidth: 80,
-    flex: 0.5,
+    flex: 1,
     sortable: false,
     filterable: false,
     renderCell: (params) => (

--- a/src/views/donationItemView/index.tsx
+++ b/src/views/donationItemView/index.tsx
@@ -16,7 +16,11 @@ import {
   Button,
 } from '@mui/material';
 import { DataGrid, GridColDef, GridToolbarQuickFilter } from '@mui/x-data-grid';
-import { DonationResponse } from '@/types/donation';
+import {
+  DonationResponse,
+  DonationItemResponse,
+  GroupedDonationItem,
+} from '@/types/donation';
 import EditIcon from '@mui/icons-material/Edit';
 import useMonth from '@/hooks/useMonth';
 import useSearch from '@/hooks/useSearch';
@@ -29,24 +33,6 @@ const allColumns: GridColDef[] = [
   { field: 'product', headerName: 'Product', maxWidth: 300, flex: 2 },
   { field: 'category', headerName: 'Category', maxWidth: 300, flex: 2 },
   { field: 'quantity', headerName: 'Quantity', maxWidth: 300, flex: 1 },
-  // { field: 'evaluation', headerName: 'Evaluation', maxWidth: 80, flex: 0.5 },
-  // {
-  //   field: 'barcode',
-  //   headerName: 'Barcode (if food)',
-  //   maxWidth: 200,
-  //   flex: 0.5,
-  //   renderCell: (params) =>
-  //     params.value ? (
-  //       <Chip
-  //         label={params.value}
-  //         sx={{
-  //           bgcolor: '#37954173',
-  //           border: 'solid',
-  //           borderColor: '#ABABAB',
-  //         }}
-  //       />
-  //     ) : null,
-  // },
   { field: 'price', headerName: 'Value', flex: 1 },
   {
     field: 'edit',
@@ -100,20 +86,7 @@ export default function DonationItemView({ donations }: DonationItemProps) {
 
   // Then, group items by name and aggregate quantities and values
   const groupedItems = flatItems.reduce(
-    (
-      acc: Record<
-        string,
-        {
-          item: { name: string; category: string; _id: string };
-          quantity: number;
-          totalValue: number;
-          barcode?: string;
-          evaluation: string;
-          itemIds: string[];
-        }
-      >,
-      item
-    ) => {
+    (acc: Record<string, GroupedDonationItem>, item: DonationItemResponse) => {
       const key = item.item.name;
 
       // If an item name hasn't been added yet, create a new entry


### PR DESCRIPTION
… entry on inventory page.

# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->

## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->
[MoH #79](https://github.com/hack4impact-utk/Maintenance-Team/issues/79)

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->
How do you want the evaluation column to be handled with this change? Should items of the same product and category be grouped together only if they also have the same evaluation? Currently, the evaluation column just shows the evaluation of whatever item was entered first.

I was unable to test the behavior of the editing the item entry with the edit item functionality broken in main. Could you create an issue for that? Am I allowed to create issues in the maintenance repo myself?

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
