### PR TITLE
MoH #91 Create audit server/typescript types

### DIFF
--- a/src/server/models/audit.ts
+++ b/src/server/models/audit.ts
@@ -1,42 +1,48 @@
 import { model, Model, models, Schema } from 'mongoose';
 import { auditActionType, auditDocumentType, AuditEntity } from '@/types/audit';
 
-const AuditSchema = new Schema({
-  actionType: {
-    type: String,
-    enum: auditActionType,
-    required: true,
+const AuditSchema = new Schema(
+  {
+    actionType: {
+      type: String,
+      enum: auditActionType,
+      required: true,
+    },
+    docType: {
+      type: String,
+      enum: auditDocumentType,
+      required: true,
+    },
+    user: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    doc: {
+      type: Schema.Types.ObjectId,
+      refPath: 'docType',
+      required: true,
+    },
+    timestamp: {
+      type: Date,
+      required: true,
+    },
+    oldFields: {
+      type: Map,
+      of: String,
+      required: false,
+    },
+    newFields: {
+      type: Map,
+      of: String,
+      required: false,
+    },
   },
-  docType: {
-    type: String,
-    enum: auditDocumentType,
-    required: true,
-  },
-  user: {
-    type: Schema.Types.ObjectId,
-    ref: 'User',
-    required: true,
-  },
-  doc: {
-    type: Schema.Types.ObjectId,
-    refPath: 'docType',
-    required: true,
-  },
-  timestamp: {
-    type: Date,
-    required: true,
-  },
-  oldFields: {
-    type: Map,
-    of: String,
-    required: false,
-  },
-  newFields: {
-    type: Map,
-    of: String,
-    required: false,
-  },
-});
+  {
+    versionKey: false,
+    tracking: true,
+  }
+);
 
 export interface AuditDocument extends Omit<AuditEntity, '_id'>, Document {}
 

--- a/src/server/models/audit.ts
+++ b/src/server/models/audit.ts
@@ -41,4 +41,4 @@ const AuditSchema = new Schema({
 export interface AuditDocument extends Omit<AuditEntity, '_id'>, Document {}
 
 export default (models.Audit as Model<AuditDocument>) ||
-  model<AuditDocument>('MailMerge', AuditSchema);
+  model<AuditDocument>('Audit', AuditSchema);

--- a/src/server/models/audit.ts
+++ b/src/server/models/audit.ts
@@ -1,0 +1,44 @@
+import { model, Model, models, Schema } from 'mongoose';
+import { auditActionType, auditDocumentType, AuditEntity } from '@/types/audit';
+
+const AuditSchema = new Schema({
+  actionType: {
+    type: String,
+    enum: auditActionType,
+    required: true,
+  },
+  docType: {
+    type: String,
+    enum: auditDocumentType,
+    required: true,
+  },
+  user: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+  },
+  doc: {
+    type: Schema.Types.ObjectId,
+    refPath: 'docType',
+    required: true,
+  },
+  timestamp: {
+    type: Date,
+    required: true,
+  },
+  oldFields: {
+    type: Map,
+    of: String,
+    required: false,
+  },
+  newFields: {
+    type: Map,
+    of: String,
+    required: false,
+  },
+});
+
+export interface AuditDocument extends Omit<AuditEntity, '_id'>, Document {}
+
+export default (models.Audit as Model<AuditDocument>) ||
+  model<AuditDocument>('MailMerge', AuditSchema);

--- a/src/types/audit.ts
+++ b/src/types/audit.ts
@@ -13,7 +13,7 @@ export const zAuditBase = z.object({
   docType: z.enum(auditDocumentType),
   user: zObjectId,
   doc: zObjectId,
-  timestamp: z.coerce.date(), // TODO: Figure out if this includes time or just day
+  timestamp: z.string().datetime(),
   newFields: z.map(z.string(), z.string()).optional(),
   oldFields: z.map(z.string(), z.string()).optional(),
 });

--- a/src/types/audit.ts
+++ b/src/types/audit.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import zObjectId from './objectId';
+import zBase from './base';
+import { zUserResponse } from './users';
+
+export const auditActionType = ['Add', 'Edit', 'Delete'] as const;
+
+// These must match key names for corresponding mongoose Schemas (accessible with Object.keys(models))
+export const auditDocumentType = ['Donation', 'Donor', 'DonationItem'] as const;
+
+export const zAuditBase = z.object({
+  actionType: z.enum(auditActionType),
+  docType: z.enum(auditDocumentType),
+  user: zObjectId,
+  doc: zObjectId,
+  timestamp: z.coerce.date(), // TODO: Figure out if this includes time or just day
+  newFields: z.map(z.string(), z.string()).optional(),
+  oldFields: z.map(z.string(), z.string()).optional(),
+});
+
+export const zAuditEntity = zAuditBase.extend({ ...zBase.shape });
+
+export interface AuditEntity extends z.infer<typeof zAuditEntity> {}
+
+export const zAuditResponse = zAuditEntity.extend({
+  user: zUserResponse,
+});


### PR DESCRIPTION
# Description
Added zod and mongoose types for audits.
Updated audit schema diagram (`actor` -> `user`, added `doc`)

## Relevant issue(s)

https://github.com/hack4impact-utk/Maintenance-Team/issues/91

## Questions
Mongoose provides `refType:` as a hip and cool way to populate fields with dynamic types, such as `doc`. Does zod provide any sort of dynamic typing that I could use to include an optional populated doc in `zAuditResponse`? I wasn't able to find anything, but I didn't dig for that long.

Also, is there any way to test this code before we add server actions?

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have assigned reviewers to this PR
